### PR TITLE
Add wgs84 bounding box subset for RSLC to GUNW processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+
+### Added
+- Added a `--subset LON_MIN LAT_MIN LON_MAX LAT_MAX` option that crops the input RSLCs to a WGS84 bounding box before processing, so the InSAR workflow runs on a small radar-coordinate patch (minutes instead of hours for a full frame) and the GUNW output is bounded to that area of interest.
+- Added the `hyp3_isce3.crop_rslc` module, which maps the AOI into each RSLC's radar grid with isce3 `geo2rdr` and writes a cropped RSLC. The cropped product's identification times, `boundingPolygon`, geolocation grid, and `processingInformation` metadata cubes are kept consistent with the crop so the resulting GUNW metadata reflects the AOI.
+
 ## [0.2.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The HyP3-ISCE3 plugin provides a workflow to process SAR satellite data using th
 
 ## Usage
 
-The HyP3-ISCE3 plugin provides a workflow (accessible directly in Python or via a CLI) for creating burst-based NISAR geocoded unwrapped interferogram using ISCE3 workflow.
+The HyP3-ISCE3 plugin provides a workflow (accessible directly in Python or via a CLI) for creating NISAR geocoded unwrapped interferogram using ISCE3 workflow.
 
 To run the workflow:
 
@@ -12,6 +12,15 @@ To run the workflow:
 python -m hyp3_isce3 \
   --reference NISAR_L1_PR_RSLC_005_172_A_008_2005_DHDH_A_20251122T024618_20251122T024652_X05007_N_F_J_001 \
   --secondary NISAR_L1_PR_RSLC_006_172_A_008_2005_DHDH_A_20251204T024618_20251204T024653_X05007_N_F_J_001 
+```
+
+The processing time can be reduced by using the `subset` parameter and a bounding box in the format `LON_MIN LAT_MIN LON_MAX LAT_MAX`:
+
+```
+python -m hyp3_isce3 \
+  --reference NISAR_L1_PR_RSLC_005_172_A_008_2005_DHDH_A_20251122T024618_20251122T024652_X05007_N_F_J_001 \
+  --secondary NISAR_L1_PR_RSLC_006_172_A_008_2005_DHDH_A_20251204T024618_20251204T024653_X05007_N_F_J_001 \
+  --subset 40.55 13.46 40.78 13.65
 ```
 
 ### Earthdata Login Credentials

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: hyp3-isce3-subset
+name: hyp3-isce3
 channels:
   - conda-forge
   - nodefaults

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - pandas<3
   - pyaps3
   - pygrib
+  - pyproj
   - raider>=0.4.5,<0.5.4
   - snaphu
   - utm

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: hyp3-isce3
+name: hyp3-isce3-subset
 channels:
   - conda-forge
   - nodefaults

--- a/src/hyp3_isce3/__main__.py
+++ b/src/hyp3_isce3/__main__.py
@@ -35,7 +35,7 @@ def main() -> None:
         '--subset',
         type=nullable_subset_list,
         nargs='*',
-        help='Optional WGS84 bounding box to subset the output GUNW (LON_MIN, LAT_MIN, LON_MAX, LAT_MAX)',
+        help='Optional WGS84 bounding box to subset the output GUNW (LON_MIN LAT_MIN LON_MAX LAT_MAX)',
     )
 
     args = parser.parse_args()

--- a/src/hyp3_isce3/__main__.py
+++ b/src/hyp3_isce3/__main__.py
@@ -8,6 +8,20 @@ from hyp3lib.aws import upload_file_to_s3
 from hyp3_isce3.process import process_isce3
 
 
+def nullable_subset_list(subset_string: str) -> list[str]:
+    """Returns a list of the subset.
+
+    Args:
+        subset_string: input string with the subset coordinates.
+
+    Returns:
+        subset_list: List of coordinates.
+    """
+    subset_string = subset_string.replace('None', '').strip()
+    subset_list = [coord for coord in subset_string.split(' ') if coord]
+    return subset_list
+
+
 def main() -> None:
     """HyP3 entrypoint for hyp3_isce3."""
     parser = ArgumentParser()
@@ -19,13 +33,19 @@ def main() -> None:
     parser.add_argument('--secondary', help='Name of the secondary scene')
     parser.add_argument(
         '--subset',
-        type=float,
-        nargs=4,
-        metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
-        help='Optional WGS84 bounding box to subset the output GUNW',
+        type=nullable_subset_list,
+        nargs='+',
+        help='Optional WGS84 bounding box to subset the output GUNW (LON_MIN, LAT_MIN, LON_MAX, LAT_MAX)',
     )
 
     args = parser.parse_args()
+
+    args.subset = [float(item) for sublist in args.subset for item in sublist]
+
+    if len(args.subset) == 0:
+        args.subset = None
+    elif not len(args.subset) == 4:
+        raise ValueError('The number of coordinates is not four')
 
     logging.basicConfig(
         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO

--- a/src/hyp3_isce3/__main__.py
+++ b/src/hyp3_isce3/__main__.py
@@ -17,6 +17,13 @@ def main() -> None:
     # TODO: Your arguments here
     parser.add_argument('--reference', help='Name of the reference scene')
     parser.add_argument('--secondary', help='Name of the secondary scene')
+    parser.add_argument(
+        '--subset',
+        type=float,
+        nargs=4,
+        metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
+        help='Optional WGS84 bounding box to subset the output GUNW',
+    )
 
     args = parser.parse_args()
 
@@ -27,6 +34,7 @@ def main() -> None:
     product_file = process_isce3(
         reference_scene=args.reference,
         secondary_scene=args.secondary,
+        subset=args.subset,
     )
 
     if args.bucket:

--- a/src/hyp3_isce3/__main__.py
+++ b/src/hyp3_isce3/__main__.py
@@ -34,18 +34,19 @@ def main() -> None:
     parser.add_argument(
         '--subset',
         type=nullable_subset_list,
-        nargs='+',
+        nargs='*',
         help='Optional WGS84 bounding box to subset the output GUNW (LON_MIN, LAT_MIN, LON_MAX, LAT_MAX)',
     )
 
     args = parser.parse_args()
 
-    args.subset = [float(item) for sublist in args.subset for item in sublist]
+    if args.subset is not None:
+        args.subset = [float(item) for sublist in args.subset for item in sublist]
 
-    if len(args.subset) == 0:
-        args.subset = None
-    elif not len(args.subset) == 4:
-        raise ValueError('The number of coordinates is not four')
+        if len(args.subset) == 0:
+            args.subset = None
+        elif not len(args.subset) == 4:
+            raise ValueError('The number of coordinates is not four')
 
     logging.basicConfig(
         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO

--- a/src/hyp3_isce3/crop_rslc.py
+++ b/src/hyp3_isce3/crop_rslc.py
@@ -10,20 +10,37 @@ The window is found by solving the four AOI corners into the radar grid with
 isce3 ``geo2rdr`` (zero-Doppler, at each corner's DEM height), taking the
 bounding (azimuth time, slant range) box, mapping it onto the swath axes, and
 padding by a margin to guard processing edge effects (filter kernels,
-coregistration search). A reference/secondary pair is cropped independently --
+coregistration search). The reference/secondary pair is cropped independently --
 each acquisition's window comes from its own orbit. The crop is a plain integer
-slice -- no resampling.
+padded slice -- no resampling.
 
-Cropped: ``swaths/zeroDopplerTime``, the ``frequency{A,B}`` images, their
-``slantRange`` and ``validSamples``, and the radar-coordinate metadata grids
+Cropped: only ``swaths`` -- ``zeroDopplerTime``, the ``frequency{A,B}`` images,
+their ``slantRange`` and ``validSamples``. These image axes are what isce3 reads
+to build the radar grid, so cropping them is what shrinks every radar-domain
+step. Restamped: ``identification/zeroDoppler{Start,End}Time`` and
+``identification/boundingPolygon`` (metadata the GUNW writer copies verbatim).
+
+The window start is snapped down to a multiple of the InSAR multilook looks
+(azimuth lines, range samples). The interferogram is multilooked from the
+reference grid's first line/sample, so a crop whose origin is not on the look
+grid averages a shifted set of pixels versus a full-frame run. That is invisible
+in coherent ground (the look-cell average is smooth) but re-rolls the speckle
+realization in decorrelated areas; snapping the origin makes the cropped product
+match a full-frame run there too.
+
+Everything else is copied verbatim: we crop only what the InSAR workflow consumes
+from the swath images. The radar-coordinate metadata grids
 ``metadata/geolocationGrid`` and ``metadata/processingInformation/parameters``
-(``dopplerCentroid``, ``referenceTerrainHeight``), bracketed to span the cropped
-swath. Restamped: ``identification/zeroDoppler{Start,End}Time`` and
-``identification/boundingPolygon``. The GUNW writer copies these grids and
-identification fields from the RSLC, so cropping them keeps the GUNW consistent.
-Everything else (orbit, attitude, calibration, ...) is copied verbatim:
-the workflow interpolates these coordinate-indexed tables, and the cropped grid
-is a subset of their domain.
+(``dopplerCentroid``, ``referenceTerrainHeight``) are coordinate-indexed tables
+the workflow interpolates, and the cropped swath is a subset of their domain, so a
+full copy is valid -- the GUNW regenerates its geometry cube from the output
+geocode grid and reads the radar grid from ``swaths``, so neither needs these
+grids cropped today.
+
+This is tied to which RSLC layers the current RSLC->GUNW workflow actually reads.
+If a future processing change starts deriving GUNW layers from one of these grids,
+or adds new radar-coordinate layers to the RSLC, this crop would need to be
+extended to cover them.
 """
 
 import logging
@@ -62,13 +79,6 @@ def _padded_slice(axis: np.ndarray, lo: float, hi: float, margin: int) -> tuple[
     i0, i1 = np.searchsorted(axis, [lo, hi])
     # Pad each side and clamp to the axis bounds.
     return int(max(0, i0 - margin)), int(min(len(axis), i1 + margin))
-
-
-def _bracket(axis: np.ndarray, lo: float, hi: float) -> tuple[int, int]:
-    """Return the (start, stop) slice bracketing [lo, hi] on an axis (one node outside each side)."""
-    return max(0, int(np.searchsorted(axis, lo, 'right')) - 1), min(
-        len(axis), int(np.searchsorted(axis, hi, 'left')) + 1
-    )
 
 
 def _solve_aoi_corners(
@@ -129,19 +139,26 @@ def aoi_to_radar_window(
     bbox_wgs84: list[float],
     dem_file: str | Path,
     margin: int = 512,
+    az_looks: int = 16,
+    rg_looks: int = 7,
 ) -> dict[str, tuple[int, int]]:
     """Find the radar-coordinate crop window for ``bbox_wgs84`` in one RSLC.
 
     Solves the four AOI corners into the radar grid with isce3 ``geo2rdr`` at
     their DEM heights, then maps the bounding (azimuth time, slant range) extent
     onto the swath axes. The window is independent per RSLC -- the AOI maps to
-    different lines/pixels in each acquisition.
+    different lines/pixels in each acquisition. The window start is snapped down to
+    a multiple of the multilook looks so the crop's multilook cells line up with a
+    full-frame run (see module docstring). An AOI that overruns the swath is clamped
+    to the overlap with a warning.
 
     Args:
         slc: Open NISAR RSLC reader.
         bbox_wgs84: AOI bounding box [lon_min, lat_min, lon_max, lat_max] in WGS84 degrees.
         dem_file: Path of a DEM GeoTIFF in WGS84 (lon/lat) used for corner heights.
         margin: Padding in frequencyA samples / azimuth lines added on every side.
+        az_looks: Azimuth multilook looks; the window start line is floored to a multiple of it.
+        rg_looks: Range multilook looks; each frequency's window start sample is floored to a multiple of it.
 
     Returns:
         window: Dict of {'az': (a0, a1), 'frequencyA': (p0, p1), ...} index slices.
@@ -165,8 +182,20 @@ def aoi_to_radar_window(
     # from its own slantRange axis covering the same physical AOI extent).
     a_lo, a_hi = min(az_times), max(az_times)
     r_lo, r_hi = min(slant_ranges), max(slant_ranges)
-    window = {'az': _padded_slice(swath_t, a_lo, a_hi, margin)}
-    window |= {fr: _padded_slice(slant_axes[fr], r_lo, r_hi, margin) for fr in freq_groups}
+    if (
+        a_lo < swath_t[0]
+        or a_hi > swath_t[-1]
+        or any(r_lo < slant_axes[fr][0] or r_hi > slant_axes[fr][-1] for fr in freq_groups)
+    ):
+        log.warning('AOI extends past the swath of %s; cropping to the overlap.', Path(slc.filename).name)
+
+    # Floor the window start to a multiple of the looks (multilook alignment; see module docstring).
+    # rg_looks is the single crossmul range looks, applied to every frequency's own grid.
+    a0, a1 = _padded_slice(swath_t, a_lo, a_hi, margin)
+    window = {'az': ((a0 // az_looks) * az_looks, a1)}
+    for fr in freq_groups:
+        p0, p1 = _padded_slice(slant_axes[fr], r_lo, r_hi, margin)
+        window[fr] = ((p0 // rg_looks) * rg_looks, p1)
 
     a0, a1 = window['az']
     p0, p1 = window['frequencyA']
@@ -205,50 +234,6 @@ def _copy_cropped(src_ds: h5py.Dataset, dst_grp: h5py.Group, name: str, slices: 
     return d
 
 
-def _crop_grid_group(
-    src_grp: h5py.Group, dst_grp: h5py.Group, az_lo: float, az_hi: float, rg_lo: float, rg_hi: float
-) -> None:
-    """Crop a radar-coordinate metadata grid group (geolocationGrid, processingInformation/parameters).
-
-    The group has its own 1-D ``zeroDopplerTime``/``slantRange`` axes; data layers
-    are indexed by them (1-D on whichever axis matches, or on their trailing two
-    dims). Nested grid subgroups (e.g. ``frequency{A,B}``) are cropped recursively.
-    Axes are *bracketed* (one node outside the swath extent each side) so the
-    cropped grid still spans the swath.
-    """
-    grid_az = src_grp['zeroDopplerTime'][()]
-    grid_rg = src_grp['slantRange'][()]
-    n_az, n_rg = len(grid_az), len(grid_rg)
-    gz0, gz1 = _bracket(grid_az, az_lo, az_hi)
-    gs0, gs1 = _bracket(grid_rg, rg_lo, rg_hi)
-
-    _copy_attrs(src_grp, dst_grp)
-    for key, item in src_grp.items():
-        if isinstance(item, h5py.Group):
-            # A nested grid group (its own axes) is cropped recursively; anything
-            # else (no axes) is copied verbatim.
-            if 'zeroDopplerTime' in item and 'slantRange' in item:
-                _crop_grid_group(item, dst_grp.create_group(key), az_lo, az_hi, rg_lo, rg_hi)
-            else:
-                src_grp.copy(key, dst_grp, name=key)
-        elif key == 'zeroDopplerTime':
-            _copy_cropped(item, dst_grp, key, (slice(gz0, gz1),))
-        elif key == 'slantRange':
-            _copy_cropped(item, dst_grp, key, (slice(gs0, gs1),))
-        elif key == 'heightAboveEllipsoid':
-            src_grp.copy(key, dst_grp, name=key)  # height axis -> not az/range indexed
-        elif item.ndim >= 2 and item.shape[-2] == n_az and item.shape[-1] == n_rg:
-            sl = (slice(None),) * (item.ndim - 2) + (slice(gz0, gz1), slice(gs0, gs1))
-            _copy_cropped(item, dst_grp, key, sl)
-        elif item.ndim == 1 and item.shape[0] == n_az:
-            _copy_cropped(item, dst_grp, key, (slice(gz0, gz1),))  # az-indexed 1-D, e.g. referenceTerrainHeight
-        elif item.ndim == 1 and item.shape[0] == n_rg:
-            _copy_cropped(item, dst_grp, key, (slice(gs0, gs1),))
-        else:
-            # epsg, chirp weightings, run-config string, etc. -> not on the radar grid.
-            src_grp.copy(key, dst_grp, name=key)
-
-
 def _update_identification_times(
     dst: h5py.File, identification_path: str, units_attr: object, t0: float, t1: float
 ) -> None:
@@ -270,17 +255,23 @@ def _update_identification_times(
         dst[path][...] = value.encode() if isinstance(sample, bytes) else value
 
 
-def _bounding_polygon_wkt(geoloc_grp: h5py.Group) -> str:
-    """WKT footprint quad from a cropped geolocationGrid's corner lon/lat nodes.
+def _bounding_polygon_wkt(geoloc_grp: h5py.Group, az_lo: float, az_hi: float, rg_lo: float, rg_hi: float) -> str:
+    """WKT footprint quad for the cropped swath, from the (full) geolocationGrid.
 
-    The grid's ``coordinateX``/``coordinateY`` are lon/lat (EPSG:4326); the four
-    corner nodes at a mid height level trace the cropped swath outline.
+    The grid is copied verbatim, so its ``coordinateX``/``coordinateY`` (lon/lat,
+    EPSG:4326) still span the whole frame. Window its own axes to one node outside
+    the cropped (azimuth time, slant range) extent and trace the corner nodes at a
+    mid height level to outline just the cropped swath.
     """
+    a0, a1 = _padded_slice(geoloc_grp['zeroDopplerTime'][()], az_lo, az_hi, margin=1)
+    r0, r1 = _padded_slice(geoloc_grp['slantRange'][()], rg_lo, rg_hi, margin=1)
     lon = geoloc_grp['coordinateX'][()]  # (height, azimuth, range), degrees
     lat = geoloc_grp['coordinateY'][()]
     h = lon.shape[0] // 2  # representative height level
-    corners = [(lon[h, a, r], lat[h, a, r]) for a, r in ((0, 0), (0, -1), (-1, -1), (-1, 0), (0, 0))]
-    return 'POLYGON ((' + ', '.join(f'{x:.6f} {y:.6f}' for x, y in corners) + '))'
+    a1, r1 = a1 - 1, r1 - 1  # last in-range node indices
+    corners = [(a0, r0), (a0, r1), (a1, r1), (a1, r0), (a0, r0)]
+    pts = [(lon[h, a, r], lat[h, a, r]) for a, r in corners]
+    return 'POLYGON ((' + ', '.join(f'{x:.6f} {y:.6f}' for x, y in pts) + '))'
 
 
 def _set_bounding_polygon(dst: h5py.File, identification_path: str, wkt: str) -> None:
@@ -299,20 +290,20 @@ def _set_bounding_polygon(dst: h5py.File, identification_path: str, wkt: str) ->
         d.attrs[k] = v
 
 
-def _mirror_except(src: h5py.Group, dst: h5py.Group, prune: set[str]) -> None:
-    """Copy ``src`` into ``dst`` verbatim, skipping the ``prune`` subtrees (root-relative paths).
+def _copy_except(src: h5py.Group, dst: h5py.Group, skip: set[str]) -> None:
+    """Copy ``src`` into ``dst`` verbatim, skipping the ``skip`` subtrees (root-relative paths).
 
-    Pruned objects are left for the caller to fill in cropped, but their parent
+    Skipped objects are left for the caller to fill in cropped, but their parent
     groups are created. Everything else is copied wholesale in one HDF5 call,
     preserving attrs/dtype/fill value without reading big arrays into Python.
     """
     _copy_attrs(src, dst)
     for name, item in src.items():
         path = item.name.lstrip('/')
-        if path in prune:
+        if path in skip:
             continue  # caller fills this in with a cropped version
-        if isinstance(item, h5py.Group) and any(p.startswith(f'{path}/') for p in prune):
-            _mirror_except(item, dst.create_group(name), prune)  # an ancestor of a pruned path
+        if isinstance(item, h5py.Group) and any(s.startswith(f'{path}/') for s in skip):
+            _copy_except(item, dst.create_group(name), skip)  # an ancestor of a skipped path
         else:
             src.copy(name, dst, name=name)
 
@@ -361,9 +352,9 @@ def crop_rslc(
 ) -> Path:
     """Write a cropped copy of an RSLC using a radar window.
 
-    The whole product is mirrored verbatim except the two radar-coordinate
-    subtrees (``swaths`` and ``geolocationGrid``), which are filled in cropped.
-    Identification times are restamped to the cropped extent last.
+    The whole product is copied verbatim except the ``swaths`` subtree (the image
+    grids), which is filled in cropped. Identification times and the bounding
+    polygon are restamped to the cropped extent last.
 
     Args:
         src_h5: Path of the source RSLC h5 file.
@@ -382,31 +373,28 @@ def crop_rslc(
         root = f'science/{_band(src)}'
         swaths = f'{root}/RSLC/swaths'
         geoloc = f'{root}/RSLC/metadata/geolocationGrid'
-        params = f'{root}/RSLC/metadata/processingInformation/parameters'
         identification = f'{root}/identification'
 
-        # Copy everything verbatim except the radar-coordinate subtrees, creating
-        # their parent groups so the cropped versions can attach.
-        _mirror_except(src, dst, {swaths, geoloc, params})
+        # Copy everything verbatim except the swaths image subtree (filled in cropped
+        # below); the metadata grids are left full -- see the module docstring.
+        _copy_except(src, dst, {swaths})
 
-        # Cropped-swath extent, used to bracket the geolocation grid and restamp
-        # the identification times.
+        # Cropped-swath extent, used to outline the footprint and restamp the
+        # identification times.
         swath_t = src[f'{swaths}/zeroDopplerTime']
         slant_a = src[f'{swaths}/frequencyA/slantRange'][()]
         az_lo, az_hi = float(swath_t[a0]), float(swath_t[a1 - 1])
         rg_lo, rg_hi = float(slant_a[p0a]), float(slant_a[p1a - 1])
 
-        # Fill the pruned subtrees with their cropped contents.
+        # Fill the pruned swaths subtree with its cropped contents.
         _crop_swaths_group(src[swaths], dst.create_group(swaths), window, polarizations)
-        _crop_grid_group(src[geoloc], dst.create_group(geoloc), az_lo, az_hi, rg_lo, rg_hi)
-        _crop_grid_group(src[params], dst.create_group(params), az_lo, az_hi, rg_lo, rg_hi)
 
         # Restamp identification times and footprint to the cropped extent (the
         # GUNW writer copies both straight from the reference RSLC).
         time_units = swath_t.attrs.get('units')
         if time_units is not None:
             _update_identification_times(dst, identification, time_units, az_lo, az_hi)
-        _set_bounding_polygon(dst, identification, _bounding_polygon_wkt(dst[geoloc]))
+        _set_bounding_polygon(dst, identification, _bounding_polygon_wkt(src[geoloc], az_lo, az_hi, rg_lo, rg_hi))
     log.info('Wrote cropped RSLC: %s', dst_h5)
     return dst_h5
 
@@ -417,13 +405,17 @@ def crop_rslc_pair(
     bbox_wgs84: list[float],
     dem_file: str | Path,
     out_dir: str | Path,
-    margin: int = 512,
+    margin: int,
+    az_looks: int,
+    rg_looks: int,
 ) -> tuple[str, str]:
     """Crop a reference/secondary RSLC pair to the AOI radar window.
 
     Each file's window is solved independently from its own orbit (the AOI maps to
     different lines/pixels in each acquisition); ``margin`` guards processing edge
-    effects (filter kernels, coregistration search).
+    effects (filter kernels, coregistration search). ``az_looks``/``rg_looks`` must
+    match the InSAR multilook looks so each crop's multilook cells align with a
+    full-frame run.
 
     Args:
         reference_rslc: Path of the reference RSLC h5 file.
@@ -432,6 +424,8 @@ def crop_rslc_pair(
         dem_file: Path of a DEM GeoTIFF in WGS84 used for corner heights.
         out_dir: Directory to write the cropped RSLCs into.
         margin: Padding in frequencyA samples / azimuth lines added on every side.
+        az_looks: Azimuth multilook looks (the InSAR crossmul value); window starts are floored to it.
+        rg_looks: Range multilook looks (the InSAR crossmul value); window starts are floored to it.
 
     Returns:
         paths: (ref_sub_path, sec_sub_path) of the cropped RSLCs.
@@ -439,11 +433,14 @@ def crop_rslc_pair(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    def crop_one(src: str | Path) -> str:
+    def crop_one(src: str | Path, ref_or_sec: str) -> str:
         slc = SLC(hdf5file=str(src))  # one reader per file, shared by both steps
-        window = aoi_to_radar_window(slc, bbox_wgs84, dem_file, margin)
+        try:
+            window = aoi_to_radar_window(slc, bbox_wgs84, dem_file, margin, az_looks, rg_looks)
+        except (ValueError, RuntimeError) as e:
+            raise ValueError(f'AOI does not fit the {ref_or_sec} RSLC {Path(src).name}: {e}') from e
         dst = out_dir / f'{Path(src).stem}_sub.h5'
         crop_rslc(src, dst, window, get_polarizations(slc))
         return str(dst)
 
-    return crop_one(reference_rslc), crop_one(secondary_rslc)
+    return crop_one(reference_rslc, 'reference'), crop_one(secondary_rslc, 'secondary')

--- a/src/hyp3_isce3/crop_rslc.py
+++ b/src/hyp3_isce3/crop_rslc.py
@@ -15,10 +15,13 @@ each acquisition's window comes from its own orbit. The crop is a plain integer
 slice -- no resampling.
 
 Cropped: ``swaths/zeroDopplerTime``, the ``frequency{A,B}`` images, their
-``slantRange`` and ``validSamples``, and ``metadata/geolocationGrid`` (bracketed
-to span the cropped swath). Restamped: ``identification/zeroDoppler{Start,End}Time``
-and ``identification/boundingPolygon`` (the GUNW writer copies both from the RSLC).
-Everything else (orbit, attitude, doppler, calibration, ...) is copied verbatim:
+``slantRange`` and ``validSamples``, and the radar-coordinate metadata grids
+``metadata/geolocationGrid`` and ``metadata/processingInformation/parameters``
+(``dopplerCentroid``, ``referenceTerrainHeight``), bracketed to span the cropped
+swath. Restamped: ``identification/zeroDoppler{Start,End}Time`` and
+``identification/boundingPolygon``. The GUNW writer copies these grids and
+identification fields from the RSLC, so cropping them keeps the GUNW consistent.
+Everything else (orbit, attitude, calibration, ...) is copied verbatim:
 the workflow interpolates these coordinate-indexed tables, and the cropped grid
 is a subset of their domain.
 """
@@ -205,11 +208,13 @@ def _copy_cropped(src_ds: h5py.Dataset, dst_grp: h5py.Group, name: str, slices: 
 def _crop_grid_group(
     src_grp: h5py.Group, dst_grp: h5py.Group, az_lo: float, az_hi: float, rg_lo: float, rg_hi: float
 ) -> None:
-    """Crop a radar-coordinate metadata grid group (e.g. geolocationGrid) into ``dst_grp``.
+    """Crop a radar-coordinate metadata grid group (geolocationGrid, processingInformation/parameters).
 
     The group has its own 1-D ``zeroDopplerTime``/``slantRange`` axes; data layers
-    are indexed by them on their trailing two dims. Axes are *bracketed* (one node
-    outside the swath extent each side) so the cropped grid still spans the swath.
+    are indexed by them (1-D on whichever axis matches, or on their trailing two
+    dims). Nested grid subgroups (e.g. ``frequency{A,B}``) are cropped recursively.
+    Axes are *bracketed* (one node outside the swath extent each side) so the
+    cropped grid still spans the swath.
     """
     grid_az = src_grp['zeroDopplerTime'][()]
     grid_rg = src_grp['slantRange'][()]
@@ -220,16 +225,27 @@ def _crop_grid_group(
     _copy_attrs(src_grp, dst_grp)
     for key, item in src_grp.items():
         if isinstance(item, h5py.Group):
-            src_grp.copy(key, dst_grp, name=key)
+            # A nested grid group (its own axes) is cropped recursively; anything
+            # else (no axes) is copied verbatim.
+            if 'zeroDopplerTime' in item and 'slantRange' in item:
+                _crop_grid_group(item, dst_grp.create_group(key), az_lo, az_hi, rg_lo, rg_hi)
+            else:
+                src_grp.copy(key, dst_grp, name=key)
         elif key == 'zeroDopplerTime':
             _copy_cropped(item, dst_grp, key, (slice(gz0, gz1),))
         elif key == 'slantRange':
             _copy_cropped(item, dst_grp, key, (slice(gs0, gs1),))
+        elif key == 'heightAboveEllipsoid':
+            src_grp.copy(key, dst_grp, name=key)  # height axis -> not az/range indexed
         elif item.ndim >= 2 and item.shape[-2] == n_az and item.shape[-1] == n_rg:
             sl = (slice(None),) * (item.ndim - 2) + (slice(gz0, gz1), slice(gs0, gs1))
             _copy_cropped(item, dst_grp, key, sl)
+        elif item.ndim == 1 and item.shape[0] == n_az:
+            _copy_cropped(item, dst_grp, key, (slice(gz0, gz1),))  # az-indexed 1-D, e.g. referenceTerrainHeight
+        elif item.ndim == 1 and item.shape[0] == n_rg:
+            _copy_cropped(item, dst_grp, key, (slice(gs0, gs1),))
         else:
-            # Height axis (heightAboveEllipsoid), epsg, etc. -> not on the radar grid.
+            # epsg, chirp weightings, run-config string, etc. -> not on the radar grid.
             src_grp.copy(key, dst_grp, name=key)
 
 
@@ -366,11 +382,12 @@ def crop_rslc(
         root = f'science/{_band(src)}'
         swaths = f'{root}/RSLC/swaths'
         geoloc = f'{root}/RSLC/metadata/geolocationGrid'
+        params = f'{root}/RSLC/metadata/processingInformation/parameters'
         identification = f'{root}/identification'
 
-        # Copy everything verbatim except the two cropped subtrees, creating their
-        # parent groups so the cropped versions can attach.
-        _mirror_except(src, dst, {swaths, geoloc})
+        # Copy everything verbatim except the radar-coordinate subtrees, creating
+        # their parent groups so the cropped versions can attach.
+        _mirror_except(src, dst, {swaths, geoloc, params})
 
         # Cropped-swath extent, used to bracket the geolocation grid and restamp
         # the identification times.
@@ -382,6 +399,7 @@ def crop_rslc(
         # Fill the pruned subtrees with their cropped contents.
         _crop_swaths_group(src[swaths], dst.create_group(swaths), window, polarizations)
         _crop_grid_group(src[geoloc], dst.create_group(geoloc), az_lo, az_hi, rg_lo, rg_hi)
+        _crop_grid_group(src[params], dst.create_group(params), az_lo, az_hi, rg_lo, rg_hi)
 
         # Restamp identification times and footprint to the cropped extent (the
         # GUNW writer copies both straight from the reference RSLC).

--- a/src/hyp3_isce3/crop_rslc.py
+++ b/src/hyp3_isce3/crop_rslc.py
@@ -1,0 +1,431 @@
+"""Crop a NISAR L1 RSLC to a small radar-coordinate window.
+
+The isce3 ``nisar.workflows.insar`` pipeline runs every pre-geocoding step in
+radar geometry over the full swath, so a geocode bounding box does not make it
+cheaper -- the inputs themselves must be small. This module maps an area of
+interest (AOI) bounding box into an RSLC's radar grid and writes a cropped copy
+holding only that (azimuth line, range sample) window.
+
+The window is found by solving the four AOI corners into the radar grid with
+isce3 ``geo2rdr`` (zero-Doppler, at each corner's DEM height), taking the
+bounding (azimuth time, slant range) box, mapping it onto the swath axes, and
+padding by a margin to guard processing edge effects (filter kernels,
+coregistration search). A reference/secondary pair is cropped independently --
+each acquisition's window comes from its own orbit. The crop is a plain integer
+slice -- no resampling.
+
+Cropped: ``swaths/zeroDopplerTime``, the ``frequency{A,B}`` images, their
+``slantRange`` and ``validSamples``, and ``metadata/geolocationGrid`` (bracketed
+to span the cropped swath). Restamped: ``identification/zeroDoppler{Start,End}Time``
+and ``identification/boundingPolygon`` (the GUNW writer copies both from the RSLC).
+Everything else (orbit, attitude, doppler, calibration, ...) is copied verbatim:
+the workflow interpolates these coordinate-indexed tables, and the cropped grid
+is a subset of their domain.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import h5py
+import isce3
+import numpy as np
+from nisar.products.readers import SLC
+
+
+log = logging.getLogger(__name__)
+
+
+def _band(h5: h5py.File) -> str:
+    """Return the NISAR SAR band group under /science (LSAR for L-band, SSAR for S-band)."""
+    band = next((b for b in h5['science'] if 'RSLC' in h5[f'science/{b}']), None)
+    if band is None:
+        raise ValueError(f'No RSLC band group found under /science in {h5.filename}')
+    return band
+
+
+def _copy_attrs(src: h5py.Group | h5py.Dataset, dst: h5py.Group | h5py.Dataset) -> None:
+    """Copy all HDF5 attributes from ``src`` onto ``dst``."""
+    for k, v in src.attrs.items():
+        dst.attrs[k] = v
+
+
+def _padded_slice(axis: np.ndarray, lo: float, hi: float, margin: int) -> tuple[int, int]:
+    """Return a padded (start, stop) slice covering [lo, hi] on a strictly increasing axis."""
+    if np.any(np.diff(axis) <= 0):
+        raise ValueError('Axis must be strictly increasing for searchsorted to be valid.')
+    if hi < axis[0] or lo > axis[-1]:
+        raise ValueError(f'Requested extent {lo:.3f}-{hi:.3f} does not overlap the axis bounds.')
+    i0, i1 = np.searchsorted(axis, [lo, hi])
+    # Pad each side and clamp to the axis bounds.
+    return int(max(0, i0 - margin)), int(min(len(axis), i1 + margin))
+
+
+def _bracket(axis: np.ndarray, lo: float, hi: float) -> tuple[int, int]:
+    """Return the (start, stop) slice bracketing [lo, hi] on an axis (one node outside each side)."""
+    return max(0, int(np.searchsorted(axis, lo, 'right')) - 1), min(
+        len(axis), int(np.searchsorted(axis, hi, 'left')) + 1
+    )
+
+
+def _solve_aoi_corners(
+    orbit: isce3.core.Orbit,
+    radar_grid: isce3.product.RadarGridParameters,
+    bbox_wgs84: list[float],
+    dem_file: str | Path,
+) -> tuple[list[float], list[float]]:
+    """geo2rdr the four AOI corners into the radar grid; return (az_times, slant_ranges).
+
+    Each corner is taken at its DEM height (bilinear; the DEM's reference height
+    outside its extent) and solved zero-Doppler, since NISAR RSLC is zero-Doppler
+    processed. geo2rdr solves one point at a time, so the corners are looped.
+    """
+    ellipsoid = isce3.core.Ellipsoid()
+    zero_doppler = isce3.core.LUT2d()  # empty LUT == Doppler 0 (zero-Doppler RSLC)
+    dem_raster = isce3.io.Raster(str(dem_file))
+    dem = isce3.geometry.DEMInterpolator(dem_raster)
+    dem.load_dem(dem_raster)
+
+    lon_min, lat_min, lon_max, lat_max = bbox_wgs84
+    corners = [(lon_min, lat_min), (lon_min, lat_max), (lon_max, lat_min), (lon_max, lat_max)]
+    az_times, slant_ranges = [], []
+    for lon, lat in corners:
+        lon_rad, lat_rad = np.radians(lon), np.radians(lat)
+        llh = np.array([lon_rad, lat_rad, dem.interpolate_lonlat(lon_rad, lat_rad)])
+        try:
+            aztime, srange = isce3.geometry.geo2rdr(
+                llh, ellipsoid, orbit, zero_doppler, radar_grid.wavelength, radar_grid.lookside
+            )
+        except RuntimeError as e:
+            # geo2rdr does not converge for a corner off the reachable geometry.
+            raise ValueError(
+                f'geo2rdr could not solve AOI corner (lon={lon}, lat={lat}); the AOI may not overlap this acquisition.'
+            ) from e
+        az_times.append(aztime)
+        slant_ranges.append(srange)
+    return az_times, slant_ranges
+
+
+def _check_epoch_alignment(radar_grid: isce3.product.RadarGridParameters, swath_t: np.ndarray) -> None:
+    """Fail if the radar-grid epoch disagrees with the swath time axis.
+
+    geo2rdr azimuth times index into ``swath_t`` only if both count from the same
+    epoch (``radar_grid.sensing_start == swath_t[0]`` for NISAR); tolerate under
+    half an azimuth sample, beyond which every line index would be shifted.
+    """
+    az_spacing = swath_t[1] - swath_t[0]
+    if abs(radar_grid.sensing_start - swath_t[0]) > 0.5 * az_spacing:
+        raise RuntimeError(
+            'RSLC radar-grid epoch does not match the swath zeroDopplerTime '
+            'axis; geo2rdr azimuth times would be offset.'
+        )
+
+
+def aoi_to_radar_window(
+    slc: SLC,
+    bbox_wgs84: list[float],
+    dem_file: str | Path,
+    margin: int = 512,
+) -> dict[str, tuple[int, int]]:
+    """Find the radar-coordinate crop window for ``bbox_wgs84`` in one RSLC.
+
+    Solves the four AOI corners into the radar grid with isce3 ``geo2rdr`` at
+    their DEM heights, then maps the bounding (azimuth time, slant range) extent
+    onto the swath axes. The window is independent per RSLC -- the AOI maps to
+    different lines/pixels in each acquisition.
+
+    Args:
+        slc: Open NISAR RSLC reader.
+        bbox_wgs84: AOI bounding box [lon_min, lat_min, lon_max, lat_max] in WGS84 degrees.
+        dem_file: Path of a DEM GeoTIFF in WGS84 (lon/lat) used for corner heights.
+        margin: Padding in frequencyA samples / azimuth lines added on every side.
+
+    Returns:
+        window: Dict of {'az': (a0, a1), 'frequencyA': (p0, p1), ...} index slices.
+    """
+    # frequencyA radar grid supplies the wavelength and look side geo2rdr needs
+    # (geometry is shared across frequencies, and frequencyA is always present).
+    radar_grid = slc.getRadarGrid('A')
+    freq_groups = [f'frequency{x}' for x in slc.frequencies]
+    az_times, slant_ranges = _solve_aoi_corners(slc.getOrbit(), radar_grid, bbox_wgs84, dem_file)
+
+    # Read the stored swath axes (independent of the radar grid, so the epoch
+    # check below is a real cross-check) and window each one.
+    with h5py.File(slc.filename, 'r') as f:
+        swaths = f'science/{_band(f)}/RSLC/swaths'
+        swath_t = f[f'{swaths}/zeroDopplerTime'][()]
+        slant_axes = {fr: f[f'{swaths}/{fr}/slantRange'][()] for fr in freq_groups}
+
+    _check_epoch_alignment(radar_grid, swath_t)
+
+    # Shared azimuth window, plus an independent range window per frequency (each
+    # from its own slantRange axis covering the same physical AOI extent).
+    a_lo, a_hi = min(az_times), max(az_times)
+    r_lo, r_hi = min(slant_ranges), max(slant_ranges)
+    window = {'az': _padded_slice(swath_t, a_lo, a_hi, margin)}
+    window |= {fr: _padded_slice(slant_axes[fr], r_lo, r_hi, margin) for fr in freq_groups}
+
+    a0, a1 = window['az']
+    p0, p1 = window['frequencyA']
+    log.info('Radar window %s: az %d lines, frequencyA %d px', Path(slc.filename).name, a1 - a0, p1 - p0)
+    return window
+
+
+def get_polarizations(slc: SLC) -> dict[str, list[str]]:
+    """Return the polarizations per frequency group for an RSLC.
+
+    Reads them from the NISAR product reader (spec-maintained upstream) so the
+    HDF5 layout for frequencies/polarizations is not hard-coded here.
+
+    Args:
+        slc: Open NISAR RSLC reader.
+
+    Returns:
+        polarizations: Frequency group name -> polarization list (e.g. {'frequencyA': ['HH', 'HV']}).
+    """
+    return {f'frequency{x}': slc.polarizations[x] for x in slc.frequencies}
+
+
+def _copy_cropped(src_ds: h5py.Dataset, dst_grp: h5py.Group, name: str, slices: tuple[slice, ...]) -> h5py.Dataset:
+    """Create ``name`` in ``dst_grp`` from ``src_ds[slices]``, preserving storage layout and attrs."""
+    data = src_ds[slices]
+    # Preserve the source storage layout (chunked/compressed) so cropped images
+    # stay compressed; clamp chunk dims to the (smaller) cropped shape.
+    kwargs = {}
+    if src_ds.chunks is not None:
+        kwargs['chunks'] = tuple(min(c, s) for c, s in zip(src_ds.chunks, data.shape))
+        kwargs['compression'] = src_ds.compression
+        kwargs['compression_opts'] = src_ds.compression_opts
+        kwargs['shuffle'] = src_ds.shuffle
+    d = dst_grp.create_dataset(name, data=data, **kwargs)
+    _copy_attrs(src_ds, d)
+    return d
+
+
+def _crop_grid_group(
+    src_grp: h5py.Group, dst_grp: h5py.Group, az_lo: float, az_hi: float, rg_lo: float, rg_hi: float
+) -> None:
+    """Crop a radar-coordinate metadata grid group (e.g. geolocationGrid) into ``dst_grp``.
+
+    The group has its own 1-D ``zeroDopplerTime``/``slantRange`` axes; data layers
+    are indexed by them on their trailing two dims. Axes are *bracketed* (one node
+    outside the swath extent each side) so the cropped grid still spans the swath.
+    """
+    grid_az = src_grp['zeroDopplerTime'][()]
+    grid_rg = src_grp['slantRange'][()]
+    n_az, n_rg = len(grid_az), len(grid_rg)
+    gz0, gz1 = _bracket(grid_az, az_lo, az_hi)
+    gs0, gs1 = _bracket(grid_rg, rg_lo, rg_hi)
+
+    _copy_attrs(src_grp, dst_grp)
+    for key, item in src_grp.items():
+        if isinstance(item, h5py.Group):
+            src_grp.copy(key, dst_grp, name=key)
+        elif key == 'zeroDopplerTime':
+            _copy_cropped(item, dst_grp, key, (slice(gz0, gz1),))
+        elif key == 'slantRange':
+            _copy_cropped(item, dst_grp, key, (slice(gs0, gs1),))
+        elif item.ndim >= 2 and item.shape[-2] == n_az and item.shape[-1] == n_rg:
+            sl = (slice(None),) * (item.ndim - 2) + (slice(gz0, gz1), slice(gs0, gs1))
+            _copy_cropped(item, dst_grp, key, sl)
+        else:
+            # Height axis (heightAboveEllipsoid), epsg, etc. -> not on the radar grid.
+            src_grp.copy(key, dst_grp, name=key)
+
+
+def _update_identification_times(
+    dst: h5py.File, identification_path: str, units_attr: object, t0: float, t1: float
+) -> None:
+    """Restamp the identification start/end times to the cropped swath extent.
+
+    ``t0``/``t1`` are the first/last cropped azimuth times (seconds since the epoch
+    in ``units_attr``); otherwise the crop would report the full-scene times.
+    """
+    units = units_attr.decode() if isinstance(units_attr, bytes) else str(units_attr)
+    if 'since' not in units:
+        return
+    epoch = datetime.fromisoformat(units.split('since', 1)[1].strip())
+    for field, seconds in (('zeroDopplerStartTime', t0), ('zeroDopplerEndTime', t1)):
+        path = f'{identification_path}/{field}'
+        if path not in dst:
+            continue
+        value = (epoch + timedelta(seconds=float(seconds))).isoformat()
+        sample = dst[path][()]
+        dst[path][...] = value.encode() if isinstance(sample, bytes) else value
+
+
+def _bounding_polygon_wkt(geoloc_grp: h5py.Group) -> str:
+    """WKT footprint quad from a cropped geolocationGrid's corner lon/lat nodes.
+
+    The grid's ``coordinateX``/``coordinateY`` are lon/lat (EPSG:4326); the four
+    corner nodes at a mid height level trace the cropped swath outline.
+    """
+    lon = geoloc_grp['coordinateX'][()]  # (height, azimuth, range), degrees
+    lat = geoloc_grp['coordinateY'][()]
+    h = lon.shape[0] // 2  # representative height level
+    corners = [(lon[h, a, r], lat[h, a, r]) for a, r in ((0, 0), (0, -1), (-1, -1), (-1, 0), (0, 0))]
+    return 'POLYGON ((' + ', '.join(f'{x:.6f} {y:.6f}' for x, y in corners) + '))'
+
+
+def _set_bounding_polygon(dst: h5py.File, identification_path: str, wkt: str) -> None:
+    """Replace the (full-scene) identification boundingPolygon with the cropped footprint.
+
+    The GUNW writer copies this field straight from the reference RSLC, so leaving
+    the full-frame polygon would mislabel the cropped product's footprint.
+    """
+    path = f'{identification_path}/boundingPolygon'
+    if path not in dst:
+        return
+    attrs = dict(dst[path].attrs)  # capture before delete; the dataset is resized
+    del dst[path]
+    d = dst.create_dataset(path, data=np.bytes_(wkt))
+    for k, v in attrs.items():
+        d.attrs[k] = v
+
+
+def _mirror_except(src: h5py.Group, dst: h5py.Group, prune: set[str]) -> None:
+    """Copy ``src`` into ``dst`` verbatim, skipping the ``prune`` subtrees (root-relative paths).
+
+    Pruned objects are left for the caller to fill in cropped, but their parent
+    groups are created. Everything else is copied wholesale in one HDF5 call,
+    preserving attrs/dtype/fill value without reading big arrays into Python.
+    """
+    _copy_attrs(src, dst)
+    for name, item in src.items():
+        path = item.name.lstrip('/')
+        if path in prune:
+            continue  # caller fills this in with a cropped version
+        if isinstance(item, h5py.Group) and any(p.startswith(f'{path}/') for p in prune):
+            _mirror_except(item, dst.create_group(name), prune)  # an ancestor of a pruned path
+        else:
+            src.copy(name, dst, name=name)
+
+
+def _crop_frequency_group(
+    src_fr: h5py.Group, dst_fr: h5py.Group, a0: int, a1: int, p0: int, p1: int, pols: list[str]
+) -> None:
+    """Crop one ``frequency{A,B}`` subgroup: the pol images, ``slantRange``, and ``validSamples``."""
+    _copy_attrs(src_fr, dst_fr)
+    for name, item in src_fr.items():
+        if name in pols:
+            _copy_cropped(item, dst_fr, name, (slice(a0, a1), slice(p0, p1)))
+        elif name == 'slantRange':
+            _copy_cropped(item, dst_fr, name, (slice(p0, p1),))
+        elif name.startswith('validSamples'):
+            # Subset rows, shift the stored column indices into the cropped range
+            # axis, and clip to the new sample range.
+            vals = np.clip(item[a0:a1].astype(np.int64) - p0, 0, p1 - p0)
+            d = dst_fr.create_dataset(name, data=vals.astype(item.dtype))
+            _copy_attrs(item, d)
+        else:
+            src_fr.copy(name, dst_fr, name=name)  # slantRangeSpacing, listOfPolarizations, ...
+
+
+def _crop_swaths_group(
+    src_sw: h5py.Group, dst_sw: h5py.Group, window: dict[str, tuple[int, int]], polarizations: dict[str, list[str]]
+) -> None:
+    """Crop the ``swaths`` group: the shared azimuth axis and each ``frequency{A,B}`` subgroup."""
+    _copy_attrs(src_sw, dst_sw)
+    a0, a1 = window['az']
+    for name, item in src_sw.items():
+        if name.startswith('frequency'):
+            p0, p1 = window[name]
+            _crop_frequency_group(item, dst_sw.create_group(name), a0, a1, p0, p1, polarizations[name])
+        elif name == 'zeroDopplerTime':
+            _copy_cropped(item, dst_sw, name, (slice(a0, a1),))
+        else:
+            src_sw.copy(name, dst_sw, name=name)  # zeroDopplerTimeSpacing, ...
+
+
+def crop_rslc(
+    src_h5: str | Path,
+    dst_h5: str | Path,
+    window: dict[str, tuple[int, int]],
+    polarizations: dict[str, list[str]],
+) -> Path:
+    """Write a cropped copy of an RSLC using a radar window.
+
+    The whole product is mirrored verbatim except the two radar-coordinate
+    subtrees (``swaths`` and ``geolocationGrid``), which are filled in cropped.
+    Identification times are restamped to the cropped extent last.
+
+    Args:
+        src_h5: Path of the source RSLC h5 file.
+        dst_h5: Path of the cropped RSLC h5 file to write.
+        window: Index slices from :func:`aoi_to_radar_window`.
+        polarizations: Frequency group name -> polarization list from :func:`get_polarizations`.
+
+    Returns:
+        dst_h5: Path of the written cropped RSLC.
+    """
+    src_h5, dst_h5 = Path(src_h5), Path(dst_h5)
+    a0, a1 = window['az']
+    p0a, p1a = window['frequencyA']
+
+    with h5py.File(src_h5, 'r') as src, h5py.File(dst_h5, 'w') as dst:
+        root = f'science/{_band(src)}'
+        swaths = f'{root}/RSLC/swaths'
+        geoloc = f'{root}/RSLC/metadata/geolocationGrid'
+        identification = f'{root}/identification'
+
+        # Copy everything verbatim except the two cropped subtrees, creating their
+        # parent groups so the cropped versions can attach.
+        _mirror_except(src, dst, {swaths, geoloc})
+
+        # Cropped-swath extent, used to bracket the geolocation grid and restamp
+        # the identification times.
+        swath_t = src[f'{swaths}/zeroDopplerTime']
+        slant_a = src[f'{swaths}/frequencyA/slantRange'][()]
+        az_lo, az_hi = float(swath_t[a0]), float(swath_t[a1 - 1])
+        rg_lo, rg_hi = float(slant_a[p0a]), float(slant_a[p1a - 1])
+
+        # Fill the pruned subtrees with their cropped contents.
+        _crop_swaths_group(src[swaths], dst.create_group(swaths), window, polarizations)
+        _crop_grid_group(src[geoloc], dst.create_group(geoloc), az_lo, az_hi, rg_lo, rg_hi)
+
+        # Restamp identification times and footprint to the cropped extent (the
+        # GUNW writer copies both straight from the reference RSLC).
+        time_units = swath_t.attrs.get('units')
+        if time_units is not None:
+            _update_identification_times(dst, identification, time_units, az_lo, az_hi)
+        _set_bounding_polygon(dst, identification, _bounding_polygon_wkt(dst[geoloc]))
+    log.info('Wrote cropped RSLC: %s', dst_h5)
+    return dst_h5
+
+
+def crop_rslc_pair(
+    reference_rslc: str | Path,
+    secondary_rslc: str | Path,
+    bbox_wgs84: list[float],
+    dem_file: str | Path,
+    out_dir: str | Path,
+    margin: int = 512,
+) -> tuple[str, str]:
+    """Crop a reference/secondary RSLC pair to the AOI radar window.
+
+    Each file's window is solved independently from its own orbit (the AOI maps to
+    different lines/pixels in each acquisition); ``margin`` guards processing edge
+    effects (filter kernels, coregistration search).
+
+    Args:
+        reference_rslc: Path of the reference RSLC h5 file.
+        secondary_rslc: Path of the secondary RSLC h5 file.
+        bbox_wgs84: AOI bounding box [lon_min, lat_min, lon_max, lat_max] in WGS84 degrees.
+        dem_file: Path of a DEM GeoTIFF in WGS84 used for corner heights.
+        out_dir: Directory to write the cropped RSLCs into.
+        margin: Padding in frequencyA samples / azimuth lines added on every side.
+
+    Returns:
+        paths: (ref_sub_path, sec_sub_path) of the cropped RSLCs.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def crop_one(src: str | Path) -> str:
+        slc = SLC(hdf5file=str(src))  # one reader per file, shared by both steps
+        window = aoi_to_radar_window(slc, bbox_wgs84, dem_file, margin)
+        dst = out_dir / f'{Path(src).stem}_sub.h5'
+        crop_rslc(src, dst, window, get_polarizations(slc))
+        return str(dst)
+
+    return crop_one(reference_rslc), crop_one(secondary_rslc)

--- a/src/hyp3_isce3/process.py
+++ b/src/hyp3_isce3/process.py
@@ -19,6 +19,9 @@ import hyp3_isce3
 from hyp3_isce3.crop_rslc import crop_rslc_pair
 
 
+asf.constants.INTERNAL.CMR_TIMEOUT = 90
+
+
 log = logging.getLogger(__name__)
 
 

--- a/src/hyp3_isce3/process.py
+++ b/src/hyp3_isce3/process.py
@@ -13,8 +13,10 @@ from hyp3lib.dem import prepare_dem_geotiff
 from nisar.workflows import h5_prep, insar, stage_dem
 from nisar.workflows.insar_runconfig import InsarRunConfig
 from osgeo import ogr, osr
+from pyproj import Transformer
 
 import hyp3_isce3
+from hyp3_isce3.crop_rslc import crop_rslc_pair
 
 
 log = logging.getLogger(__name__)
@@ -29,6 +31,8 @@ def get_config(
     secondary_tropo: str,
     tec_path: str,
     watermask: str,
+    subset_utm: tuple[float, float, float, float] | None = None,
+    output_epsg: int | None = None,
 ) -> Path:
     """Create a configuration file for isce3.
 
@@ -41,6 +45,8 @@ def get_config(
         secondary_tropo: Path of the ECMWF file for the secondary scene.
         tec_path: Path of the TEC file for the reference scene.
         watermask: Path of the water mask file.
+        subset_utm: Optional (xmin, ymin, xmax, ymax) output box in UTM meters.
+        output_epsg: EPSG code of ``subset_utm``; written into the geocode blocks so the corners and projection stay consistent.
 
     Returns:
         yaml_file: Path of the configuration file.
@@ -81,7 +87,29 @@ def get_config(
                 newstring = line
             yaml.write(newstring)
 
+        # When subsetting, pin the geocode and radar_grid_cubes output grids to
+        # the AOI: set each block's output_epsg to the same zone we used for the
+        # corners (so corners and projection are consistent rather than trusting
+        # the downloaded config's epsg), then overwrite top_left / bottom_right.
+        # Both blocks list top_left then bottom_right (each with y_abs then
+        # x_abs); the dem_download block uses x/y, not x_abs/y_abs, so it is
+        # untouched. (The radar-domain steps are shrunk by the RSLC crop, not by
+        # these output grids.)
+        xmin, ymin, xmax, ymax = subset_utm if subset_utm else (None, None, None, None)
+        corner = 0
         for line in lines_tmp[first::]:
+            if subset_utm is None:
+                pass
+            elif 'output_epsg' in line:
+                line = f'{line.partition(":")[0]}: {output_epsg}\n'
+            elif 'top_left' in line:
+                corner = 1
+            elif 'bottom_right' in line:
+                corner = 2
+            elif corner and 'x_abs' in line:
+                line = f'{line.partition(":")[0]}: {xmin if corner == 1 else xmax}\n'
+            elif corner and 'y_abs' in line:
+                line = f'{line.partition(":")[0]}: {ymax if corner == 1 else ymin}\n'
             yaml.write(line)
 
     return Path('insar.yaml')
@@ -259,6 +287,23 @@ def get_epsg(lat: float, lon: float) -> int:
     return epsg_base + zone_number
 
 
+def reproject_subset(subset: list[float], epsg_code: int) -> tuple[float, float, float, float]:
+    """Reproject a WGS84 lon/lat subset box to the output UTM projection.
+
+    Args:
+        subset: WGS84 bounding box as [lon_min, lat_min, lon_max, lat_max].
+        epsg_code: Output UTM EPSG code.
+
+    Returns:
+        bbox: Enclosing (xmin, ymin, xmax, ymax) box in UTM meters.
+    """
+    lon_min, lat_min, lon_max, lat_max = subset
+    # transform_bounds densifies the edges, so the returned box encloses the
+    # reprojected lon/lat rectangle even where its boundary bulges between corners.
+    transformer = Transformer.from_crs('EPSG:4326', f'EPSG:{epsg_code}', always_xy=True)
+    return transformer.transform_bounds(lon_min, lat_min, lon_max, lat_max)
+
+
 def get_scene_polygon(reference_path: str) -> ogr.Geometry:
     """Get Polygon for reference scene.
 
@@ -307,12 +352,13 @@ def get_product_id(reference_scene: str, secondary_scene: str) -> str:
     return product_id
 
 
-def process_isce3(reference_scene: str, secondary_scene: str) -> Path:
+def process_isce3(reference_scene: str, secondary_scene: str, subset: list[float] | None = None) -> Path:
     """Get Polygon for reference scene.
 
     Args:
         reference_scene: Name of the reference scene.
         secondary_scene: Name of the secondary scene.
+        subset: Optional WGS84 bounding box [lon_min, lat_min, lon_max, lat_max] to subset the output GUNW.
 
     Returns:
         h5file: Path of the GUNW h5file.
@@ -334,7 +380,19 @@ def process_isce3(reference_scene: str, secondary_scene: str) -> Path:
     tec_path = get_tec(reference_scene)
 
     scene_polygon, epsg_code = get_scene_polygon(reference_path)
-    _ = get_dem(scene_polygon, epsg_code)
+    dem_path = get_dem(scene_polygon, epsg_code)
+
+    # Subset the RSLCs to the area of interest before processing so every
+    # radar-domain step runs on a small patch instead of the full frame. The
+    # crop uses the raw lon/lat AOI (geo2rdr is geodetic); the runconfig geocode
+    # grids need the same AOI in UTM meters.
+    subset_utm = None
+    if subset:
+        subset_utm = reproject_subset(subset, epsg_code)
+        reference_path, secondary_path = crop_rslc_pair(
+            reference_path, secondary_path, subset, dem_path, out_dir='.', margin=512
+        )
+
     yaml_path = get_config(
         reference_path,
         secondary_path,
@@ -344,6 +402,8 @@ def process_isce3(reference_scene: str, secondary_scene: str) -> Path:
         secondary_tropo,
         tec_path,
         watermask,
+        subset_utm,
+        epsg_code,
     )
     args = argparse.Namespace(run_config_path=str(yaml_path), log_file=False)
     insar_runcfg = InsarRunConfig(args)

--- a/src/hyp3_isce3/process.py
+++ b/src/hyp3_isce3/process.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import asf_search as asf
 import earthaccess
 import utm
+import yaml
 from hyp3lib.dem import prepare_dem_geotiff
 from nisar.workflows import h5_prep, insar, stage_dem
 from nisar.workflows.insar_runconfig import InsarRunConfig
@@ -34,6 +35,7 @@ def get_config(
     secondary_tropo: str,
     tec_path: str,
     watermask: str,
+    template_yaml: Path,
     subset_utm: tuple[float, float, float, float] | None = None,
     output_epsg: int | None = None,
 ) -> Path:
@@ -48,26 +50,29 @@ def get_config(
         secondary_tropo: Path of the ECMWF file for the secondary scene.
         tec_path: Path of the TEC file for the reference scene.
         watermask: Path of the water mask file.
+        template_yaml: Path of the downloaded JPL runconfig (from :func:`download_yaml`) used as the tail/template.
         subset_utm: Optional (xmin, ymin, xmax, ymax) output box in UTM meters.
         output_epsg: EPSG code of ``subset_utm``; written into the geocode blocks so the corners and projection stay consistent.
 
     Returns:
         yaml_file: Path of the configuration file.
     """
-    tmp_yaml = download_yaml(reference_path)
-    with tmp_yaml.open('r') as yaml:
-        lines_tmp = yaml.readlines()
+    # Keep the downloaded runconfig's tail (product_path_group on) and splice our
+    # schema header in front. The caller owns template_yaml, so we don't delete it.
+    with Path(template_yaml).open('r') as f:
+        lines_tmp = f.readlines()
         for first, line in enumerate(lines_tmp):
             if 'product_path_group:' in line:
                 break
-    tmp_yaml.unlink()
 
+    # Our shipped schema is the header (input/ancillary file groups) with
+    # placeholder tokens standing in for the real scene/orbit/ancillary paths.
     yaml_schema = Path(hyp3_isce3.__file__).parent / 'schemas' / 'insar.yaml'
-    with yaml_schema.open('r') as yaml:
-        lines = yaml.readlines()
+    with yaml_schema.open('r') as f:
+        lines = f.readlines()
 
     yaml_file = Path('insar.yaml')
-    with yaml_file.open('w') as yaml:
+    with yaml_file.open('w') as out:
         for line in lines:
             newstring = ''
             if 'reference_scene' in line:
@@ -88,16 +93,10 @@ def get_config(
                 newstring += line.replace('watermask', watermask)
             else:
                 newstring = line
-            yaml.write(newstring)
+            out.write(newstring)
 
-        # When subsetting, pin the geocode and radar_grid_cubes output grids to
-        # the AOI: set each block's output_epsg to the same zone we used for the
-        # corners (so corners and projection are consistent rather than trusting
-        # the downloaded config's epsg), then overwrite top_left / bottom_right.
-        # Both blocks list top_left then bottom_right (each with y_abs then
-        # x_abs); the dem_download block uses x/y, not x_abs/y_abs, so it is
-        # untouched. (The radar-domain steps are shrunk by the RSLC crop, not by
-        # these output grids.)
+        # Pin the geocode and radar_grid_cubes output grids to the AOI and projection.
+        # The RSLC crop carries a margin, so this geocode box is the final crop.
         xmin, ymin, xmax, ymax = subset_utm if subset_utm else (None, None, None, None)
         corner = 0
         for line in lines_tmp[first::]:
@@ -113,9 +112,27 @@ def get_config(
                 line = f'{line.partition(":")[0]}: {xmin if corner == 1 else xmax}\n'
             elif corner and 'y_abs' in line:
                 line = f'{line.partition(":")[0]}: {ymax if corner == 1 else ymin}\n'
-            yaml.write(line)
+            out.write(line)
 
     return Path('insar.yaml')
+
+
+def get_crossmul_looks(template_yaml: Path) -> tuple[int, int]:
+    """Read the InSAR crossmul (azimuth, range) multilook looks from the runconfig template.
+
+    The RSLC crop floors its window origin to these so the crop's multilook cells
+    coincide with a full-frame run. Sourcing them from the same runconfig the
+    workflow runs guarantees the two never drift. If looks are ever exposed as a
+    user/processing parameter, read that parameter here instead so the crop tracks it.
+
+    Args:
+        template_yaml: Path of the downloaded JPL runconfig (from :func:`download_yaml`).
+
+    Returns:
+        looks: (azimuth_looks, range_looks) from the runconfig ``crossmul`` block.
+    """
+    crossmul = yaml.safe_load(Path(template_yaml).read_text())['runconfig']['groups']['processing']['crossmul']
+    return int(crossmul['azimuth_looks']), int(crossmul['range_looks'])
 
 
 def download_yaml(reference_path: str) -> Path:
@@ -385,15 +402,25 @@ def process_isce3(reference_scene: str, secondary_scene: str, subset: list[float
     scene_polygon, epsg_code = get_scene_polygon(reference_path)
     dem_path = get_dem(scene_polygon, epsg_code)
 
-    # Subset the RSLCs to the area of interest before processing so every
-    # radar-domain step runs on a small patch instead of the full frame. The
-    # crop uses the raw lon/lat AOI (geo2rdr is geodetic); the runconfig geocode
-    # grids need the same AOI in UTM meters.
+    # The JPL runconfig is both our config template (its tail) and the source of the
+    # crossmul looks the crop aligns to; download once and reuse for both.
+    template_yaml = download_yaml(reference_path)
+
+    # Crop the RSLCs to the AOI before processing so the radar-domain steps run on a
+    # small patch; the crop floors its origin to the crossmul looks (see crop_rslc).
     subset_utm = None
     if subset:
         subset_utm = reproject_subset(subset, epsg_code)
+        az_looks, rg_looks = get_crossmul_looks(template_yaml)
         reference_path, secondary_path = crop_rslc_pair(
-            reference_path, secondary_path, subset, dem_path, out_dir='.', margin=512
+            reference_path,
+            secondary_path,
+            subset,
+            dem_path,
+            out_dir='.',
+            margin=512,
+            az_looks=az_looks,
+            rg_looks=rg_looks,
         )
 
     yaml_path = get_config(
@@ -405,9 +432,12 @@ def process_isce3(reference_scene: str, secondary_scene: str, subset: list[float
         secondary_tropo,
         tec_path,
         watermask,
+        template_yaml,
         subset_utm,
         epsg_code,
     )
+    template_yaml.unlink()  # consumed by the looks read and the config build
+
     args = argparse.Namespace(run_config_path=str(yaml_path), log_file=False)
     insar_runcfg = InsarRunConfig(args)
 

--- a/tests/test_crop_rslc.py
+++ b/tests/test_crop_rslc.py
@@ -103,7 +103,21 @@ def _make_rslc(path):
         ident = f.create_group('science/LSAR/identification')
         ident.create_dataset('zeroDopplerStartTime', data=np.bytes_('2025-01-01T00:00:00'))
         ident.create_dataset('zeroDopplerEndTime', data=np.bytes_('2025-01-01T00:01:39'))
-        ident.create_dataset('boundingPolygon', data=np.bytes_('POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))'))
+        ident.create_dataset(
+            'boundingPolygon', data=np.bytes_('POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))')
+        )
+
+        # processingInformation/parameters: own grid axes, a 1-D az layer, a non-grid
+        # 1-D array, and a nested per-frequency cube -> grid pieces cropped, rest kept.
+        pp = f.create_group('science/LSAR/RSLC/metadata/processingInformation/parameters')
+        pp.create_dataset('zeroDopplerTime', data=GRID_AZ)
+        pp.create_dataset('slantRange', data=GRID_RG)
+        pp.create_dataset('referenceTerrainHeight', data=np.arange(N_AZG, dtype='f4'))  # az-indexed
+        pp.create_dataset('rangeChirpWeighting', data=np.ones(8, dtype='f4'))  # not az/range -> verbatim
+        fa = pp.create_group('frequencyA')
+        fa.create_dataset('zeroDopplerTime', data=GRID_AZ)
+        fa.create_dataset('slantRange', data=GRID_RG)
+        fa.create_dataset('dopplerCentroid', data=np.outer(GRID_AZ, GRID_RG))  # (az, range)
 
         # A metadata dataset on no cropped axis -> must be copied byte-for-byte.
         orb = f.create_dataset(
@@ -218,6 +232,20 @@ class TestCropRslc:
         with h5py.File(dst, 'r') as f:
             assert f['science/LSAR/identification/zeroDopplerStartTime'][()].decode() == EXPECTED_START
             assert f['science/LSAR/identification/zeroDopplerEndTime'][()].decode() == EXPECTED_END
+
+    def test_processing_parameters_cubes_cropped(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        pp = 'science/LSAR/RSLC/metadata/processingInformation/parameters'
+        with h5py.File(dst, 'r') as f:
+            # Own grid axes + the 1-D az layer bracketed to [2:7].
+            np.testing.assert_array_equal(f[f'{pp}/zeroDopplerTime'][()], GRID_AZ[EXPECTED_GRID_SLICE])
+            np.testing.assert_array_equal(f[f'{pp}/slantRange'][()], GRID_RG[EXPECTED_GRID_SLICE])
+            assert f[f'{pp}/referenceTerrainHeight'].shape == (5,)
+            # Nested per-frequency dopplerCentroid cropped on both az and range.
+            assert f[f'{pp}/frequencyA/dopplerCentroid'].shape == (5, 5)
+            # A non-grid 1-D array (chirp weighting) is left untouched.
+            assert f[f'{pp}/rangeChirpWeighting'].shape == (8,)
 
     def test_bounding_polygon_recomputed(self, rslc_h5, tmp_path):
         dst = tmp_path / 'out.h5'

--- a/tests/test_crop_rslc.py
+++ b/tests/test_crop_rslc.py
@@ -6,6 +6,7 @@ directly and the writer (`crop_rslc`) against a synthetic RSLC. These tests don'
 call isce3, though importing the module does (isce3/nisar are imported at top).
 """
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -16,10 +17,9 @@ import pytest
 from hyp3_isce3 import crop_rslc as crop_mod
 from hyp3_isce3.crop_rslc import (
     _band,
-    _bracket,
     _check_epoch_alignment,
     _copy_attrs,
-    _mirror_except,
+    _copy_except,
     _padded_slice,
     crop_rslc,
     crop_rslc_pair,
@@ -155,6 +155,55 @@ class TestWindowMath:
             _padded_slice(np.array([0.0, 2.0, 1.0, 3.0]), 0.0, 3.0, MARGIN)
 
 
+class TestAoiToRadarWindow:
+    """The window solve with the geo2rdr corner solve stubbed: snap-to-looks and overrun warning."""
+
+    @staticmethod
+    def _stub_slc(rslc_h5):
+        # Only the attributes aoi_to_radar_window touches; geo2rdr is stubbed so the
+        # radar grid just needs a sensing_start matching the swath epoch (SWATH_T[0]=0).
+        return SimpleNamespace(
+            getRadarGrid=lambda freq: SimpleNamespace(sensing_start=0.0),
+            getOrbit=lambda: None,
+            frequencies=['A', 'B'],
+            filename=str(rslc_h5),
+        )
+
+    def test_window_start_floored_to_looks(self, rslc_h5, monkeypatch):
+        # Corners -> az 30-50, range 36-60 -> padded (26,54)/(32,64); starts floor
+        # to a multiple of the looks: 26 -> 16 (az 16), 32 -> 28 (rg 7).
+        monkeypatch.setattr(
+            crop_mod, '_solve_aoi_corners', lambda *a, **k: ([30.0, 30.0, 50.0, 50.0], [36.0, 36.0, 60.0, 60.0])
+        )
+        window = crop_mod.aoi_to_radar_window(
+            self._stub_slc(rslc_h5), [0.0, 0.0, 1.0, 1.0], '', margin=MARGIN, az_looks=16, rg_looks=7
+        )
+        assert window['az'] == (16, 54)
+        assert window['frequencyA'] == (28, 64)
+        # rg_looks is applied to every frequency's own grid: freqB padded (1,12) -> start floored to 0.
+        assert window['frequencyB'] == (0, 12)
+
+    def test_looks_of_one_is_no_snap(self, rslc_h5, monkeypatch):
+        monkeypatch.setattr(
+            crop_mod, '_solve_aoi_corners', lambda *a, **k: ([30.0, 30.0, 50.0, 50.0], [36.0, 36.0, 60.0, 60.0])
+        )
+        window = crop_mod.aoi_to_radar_window(
+            self._stub_slc(rslc_h5), [0.0, 0.0, 1.0, 1.0], '', margin=MARGIN, az_looks=1, rg_looks=1
+        )
+        assert window['az'] == (26, 54) and window['frequencyA'] == (32, 64)
+
+    def test_overrun_warns(self, rslc_h5, monkeypatch, caplog):
+        # Range extent reaches below the swath start -> clamped, with a warning.
+        monkeypatch.setattr(
+            crop_mod, '_solve_aoi_corners', lambda *a, **k: ([30.0, 30.0, 50.0, 50.0], [-10.0, -10.0, 60.0, 60.0])
+        )
+        with caplog.at_level(logging.WARNING):
+            crop_mod.aoi_to_radar_window(
+                self._stub_slc(rslc_h5), [0.0, 0.0, 1.0, 1.0], '', margin=MARGIN, az_looks=16, rg_looks=7
+            )
+        assert 'extends past the swath' in caplog.text
+
+
 class TestCropRslc:
     def test_shapes_and_axes(self, rslc_h5, tmp_path):
         dst = tmp_path / 'out.h5'
@@ -213,16 +262,14 @@ class TestCropRslc:
             assert ds.compression == 'gzip'
             assert ds.chunks is not None
 
-    def test_geolocation_grid_bracketed(self, rslc_h5, tmp_path):
+    def test_geolocation_grid_copied_verbatim(self, rslc_h5, tmp_path):
         dst = tmp_path / 'out.h5'
         crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
         with h5py.File(dst, 'r') as f:
-            # Own axes bracketed to span the cropped swath extent.
-            np.testing.assert_array_equal(f[f'{_GEOLOC}/zeroDopplerTime'][()], GRID_AZ[EXPECTED_GRID_SLICE])
-            np.testing.assert_array_equal(f[f'{_GEOLOC}/slantRange'][()], GRID_RG[EXPECTED_GRID_SLICE])
-            # 3-D coordinate layer sliced on its trailing (az, range) dims only.
-            assert f[f'{_GEOLOC}/coordinateX'].shape == (N_H, 5, 5)
-            # Height axis and epsg are not on the radar grid -> untouched.
+            # Copied whole -- the workflow interpolates it and the GUNW regenerates its own cube.
+            np.testing.assert_array_equal(f[f'{_GEOLOC}/zeroDopplerTime'][()], GRID_AZ)
+            np.testing.assert_array_equal(f[f'{_GEOLOC}/slantRange'][()], GRID_RG)
+            assert f[f'{_GEOLOC}/coordinateX'].shape == (N_H, N_AZG, N_RGG)
             np.testing.assert_array_equal(f[f'{_GEOLOC}/heightAboveEllipsoid'][()], GRID_HEIGHTS)
             assert f[f'{_GEOLOC}/epsg'][()] == 4326
 
@@ -233,18 +280,16 @@ class TestCropRslc:
             assert f['science/LSAR/identification/zeroDopplerStartTime'][()].decode() == EXPECTED_START
             assert f['science/LSAR/identification/zeroDopplerEndTime'][()].decode() == EXPECTED_END
 
-    def test_processing_parameters_cubes_cropped(self, rslc_h5, tmp_path):
+    def test_processing_parameters_copied_verbatim(self, rslc_h5, tmp_path):
         dst = tmp_path / 'out.h5'
         crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
         pp = 'science/LSAR/RSLC/metadata/processingInformation/parameters'
         with h5py.File(dst, 'r') as f:
-            # Own grid axes + the 1-D az layer bracketed to [2:7].
-            np.testing.assert_array_equal(f[f'{pp}/zeroDopplerTime'][()], GRID_AZ[EXPECTED_GRID_SLICE])
-            np.testing.assert_array_equal(f[f'{pp}/slantRange'][()], GRID_RG[EXPECTED_GRID_SLICE])
-            assert f[f'{pp}/referenceTerrainHeight'].shape == (5,)
-            # Nested per-frequency dopplerCentroid cropped on both az and range.
-            assert f[f'{pp}/frequencyA/dopplerCentroid'].shape == (5, 5)
-            # A non-grid 1-D array (chirp weighting) is left untouched.
+            # The whole parameters group (incl. dopplerCentroid, referenceTerrainHeight) is copied as is.
+            np.testing.assert_array_equal(f[f'{pp}/zeroDopplerTime'][()], GRID_AZ)
+            np.testing.assert_array_equal(f[f'{pp}/slantRange'][()], GRID_RG)
+            assert f[f'{pp}/referenceTerrainHeight'].shape == (N_AZG,)
+            assert f[f'{pp}/frequencyA/dopplerCentroid'].shape == (N_AZG, N_RGG)
             assert f[f'{pp}/rangeChirpWeighting'].shape == (8,)
 
     def test_bounding_polygon_recomputed(self, rslc_h5, tmp_path):
@@ -272,7 +317,14 @@ class TestCropPair:
         # bbox_wgs84/dem_file are unused here (the window solve is stubbed above),
         # but pass type-valid values so static analysis is happy.
         ref_sub, sec_sub = crop_rslc_pair(
-            rslc_h5, sec, bbox_wgs84=[0.0, 0.0, 0.0, 0.0], dem_file='', out_dir=tmp_path / 'subs', margin=MARGIN
+            rslc_h5,
+            sec,
+            bbox_wgs84=[0.0, 0.0, 0.0, 0.0],
+            dem_file='',
+            out_dir=tmp_path / 'subs',
+            margin=MARGIN,
+            az_looks=16,
+            rg_looks=7,
         )
         for p in (ref_sub, sec_sub):
             assert Path(p).exists()
@@ -280,6 +332,27 @@ class TestCropPair:
                 a0, a1 = EXPECTED_WINDOW['az']
                 assert f[f'{_SWATHS}/zeroDopplerTime'].shape == (a1 - a0,)
         assert ref_sub != sec_sub
+
+    def test_window_failure_names_the_rslc(self, rslc_h5, tmp_path, monkeypatch):
+        # An off-swath AOI fails per-file; the error should say which RSLC (ref is first).
+        monkeypatch.setattr(crop_mod, 'SLC', lambda **k: None)
+        monkeypatch.setattr(crop_mod, 'get_polarizations', lambda *a, **k: POLARIZATIONS)
+
+        def fail(*a, **k):
+            raise ValueError('AOI does not overlap')
+
+        monkeypatch.setattr(crop_mod, 'aoi_to_radar_window', fail)
+        with pytest.raises(ValueError, match='reference RSLC'):
+            crop_rslc_pair(
+                rslc_h5,
+                rslc_h5,
+                bbox_wgs84=[0.0, 0.0, 0.0, 0.0],
+                dem_file='',
+                out_dir=tmp_path / 'subs',
+                margin=MARGIN,
+                az_looks=16,
+                rg_looks=7,
+            )
 
 
 class TestBand:
@@ -305,15 +378,17 @@ class TestBand:
             _band(f)
 
 
-class TestBracket:
+class TestPaddedSliceBracket:
+    """``_padded_slice`` with margin=1 is the one-node-outside bracket used for the footprint."""
+
     def test_brackets_extent_one_node_outside(self):
         axis = np.arange(10, dtype='f8') * 10.0  # 0, 10, ..., 90
-        # searchsorted(right, 26)=3 -> 2 ; searchsorted(left, 53)=6 -> 7
-        assert _bracket(axis, 26.0, 53.0) == (2, 7)
+        # searchsorted(26)=3 -> 2 ; searchsorted(53)=6 -> 7
+        assert _padded_slice(axis, 26.0, 53.0, margin=1) == (2, 7)
 
     def test_clamps_to_axis_bounds(self):
         axis = np.arange(10, dtype='f8') * 10.0
-        assert _bracket(axis, -100.0, 1000.0) == (0, 10)
+        assert _padded_slice(axis, -10.0, 1000.0, margin=1) == (0, 10)
 
 
 class TestEpochAlignment:
@@ -348,18 +423,18 @@ def test_copy_attrs(tmp_path):
         assert dst.attrs['scale'] == 2.0
 
 
-def test_mirror_except_prunes_subtree(tmp_path):
+def test_copy_except_skips_subtree(tmp_path):
     src_path, dst_path = tmp_path / 'src.h5', tmp_path / 'dst.h5'
     with h5py.File(src_path, 'w') as f:
         f.attrs['mission'] = 'NISAR'  # root attr -> copied
-        f.create_dataset('a/keep', data=[1, 2])  # sibling of the pruned subtree
-        f.create_dataset('a/drop/x', data=[9])  # inside the pruned subtree
+        f.create_dataset('a/keep', data=[1, 2])  # sibling of the skipped subtree
+        f.create_dataset('a/drop/x', data=[9])  # inside the skipped subtree
         f.create_dataset('top', data=[7])  # unrelated branch
     with h5py.File(src_path, 'r') as src, h5py.File(dst_path, 'w') as dst:
-        _mirror_except(src, dst, {'a/drop'})
+        _copy_except(src, dst, {'a/drop'})
     with h5py.File(dst_path, 'r') as out:
         assert out.attrs['mission'] == 'NISAR'
-        assert 'a' in out  # ancestor of the pruned path is still created
+        assert 'a' in out  # ancestor of the skipped path is still created
         assert 'a/keep' in out  # sibling copied verbatim
         assert 'top' in out  # unrelated branch copied wholesale
-        assert 'a/drop' not in out  # pruned subtree skipped for the caller to fill
+        assert 'a/drop' not in out  # skipped subtree left for the caller to fill

--- a/tests/test_crop_rslc.py
+++ b/tests/test_crop_rslc.py
@@ -269,8 +269,10 @@ class TestCropPair:
         # mimic that so the per-file output names don't collide.
         sec = tmp_path / 'synthetic_rslc_sec.h5'
         _make_rslc(sec)
+        # bbox_wgs84/dem_file are unused here (the window solve is stubbed above),
+        # but pass type-valid values so static analysis is happy.
         ref_sub, sec_sub = crop_rslc_pair(
-            rslc_h5, sec, bbox_wgs84=None, dem_file=None, out_dir=tmp_path / 'subs', margin=MARGIN
+            rslc_h5, sec, bbox_wgs84=[0.0, 0.0, 0.0, 0.0], dem_file='', out_dir=tmp_path / 'subs', margin=MARGIN
         )
         for p in (ref_sub, sec_sub):
             assert Path(p).exists()

--- a/tests/test_crop_rslc.py
+++ b/tests/test_crop_rslc.py
@@ -1,0 +1,335 @@
+"""Tests for hyp3_isce3.crop_rslc.
+
+The geo2rdr-based window solve (`aoi_to_radar_window`) needs a real orbit, so it
+is not unit-tested here; instead the pure index math (`_padded_slice`) is tested
+directly and the writer (`crop_rslc`) against a synthetic RSLC. These tests don't
+call isce3, though importing the module does (isce3/nisar are imported at top).
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pytest
+
+from hyp3_isce3 import crop_rslc as crop_mod
+from hyp3_isce3.crop_rslc import (
+    _band,
+    _bracket,
+    _check_epoch_alignment,
+    _copy_attrs,
+    _mirror_except,
+    _padded_slice,
+    crop_rslc,
+    crop_rslc_pair,
+    get_polarizations,
+)
+
+
+_SWATHS = 'science/LSAR/RSLC/swaths'
+
+# --- synthetic geometry -----------------------------------------------------
+# Clean integer axes so np.searchsorted lands on exact indices.
+N_LINES = 100  # full azimuth lines
+N_RGA, N_RGB = 120, 15  # full range samples, freq A / B
+SWATH_T = np.arange(N_LINES, dtype='f8')  # 0..99
+SLANT_A = np.arange(N_RGA, dtype='f8')  # 0..119
+SLANT_B = np.arange(N_RGB, dtype='f8') * 8.0  # 0,8,..,112 (coarse, like real B)
+VALID_START, VALID_END = 10, 110  # validSamplesSubSwath1 row value
+
+MARGIN = 4
+# Radar-coord extent (az time 30-50 s, slant range 36-60 m) and the padded
+# single-axis windows from _window_from_radar_coords:
+#   az: searchsorted(SWATH_T,[30,50])=[30,50] -> +/-4 -> (26,54)
+#   A : searchsorted(SLANT_A,[36,60])=[36,60] -> +/-4 -> (32,64)
+AZ_LO, AZ_HI, RG_LO, RG_HI = 30.0, 50.0, 36.0, 60.0
+# A crop-writer fixture window (the freqB slice here is arbitrary; crop_rslc just
+# slices to whatever indices it is given).
+EXPECTED_WINDOW = {'az': (26, 54), 'frequencyA': (32, 64), 'frequencyB': (4, 9)}
+POLARIZATIONS = {'frequencyA': ['HH', 'HV'], 'frequencyB': ['HH', 'HV']}
+
+# Cropped swath physical extent for EXPECTED_WINDOW: az SWATH_T[26..53]=26..53,
+# range SLANT_A[32..63]=32..63. Epoch is 2025-01-01, so the restamped
+# identification times are epoch + 26 s and + 53 s.
+TIME_UNITS = 'seconds since 2025-01-01 00:00:00'
+EXPECTED_START = '2025-01-01T00:00:26'
+EXPECTED_END = '2025-01-01T00:00:53'
+
+# geolocationGrid axes (coarse, like real products). The bracketed crop of the
+# swath extent (az 26-53, range 32-63) onto these axes is indices [2:7] for both.
+_GEOLOC = 'science/LSAR/RSLC/metadata/geolocationGrid'
+N_H, N_AZG, N_RGG = 2, 10, 10
+GRID_HEIGHTS = np.array([0.0, 1000.0])
+GRID_AZ = np.arange(N_AZG, dtype='f8') * 10.0  # 0,10,..,90
+GRID_RG = np.arange(N_RGG, dtype='f8') * 12.0  # 0,12,..,108
+EXPECTED_GRID_SLICE = slice(2, 7)  # both axes bracket [lo, hi] to [2:7]
+
+
+def _make_rslc(path):
+    """Write a tiny but structurally-faithful synthetic RSLC."""
+    with h5py.File(path, 'w') as f:
+        f.attrs['mission_name'] = 'NISAR'  # root attr -> must be copied verbatim
+
+        sw = f.create_group(_SWATHS)
+        t = sw.create_dataset('zeroDopplerTime', data=SWATH_T)
+        t.attrs['units'] = TIME_UNITS  # attr on a cropped axis -> must survive; also the epoch
+        sw.create_dataset('zeroDopplerTimeSpacing', data=1.0)
+
+        for fr, slant in (('frequencyA', SLANT_A), ('frequencyB', SLANT_B)):
+            g = sw.create_group(fr)
+            nrg = slant.size
+            # Distinct per-(line,sample) values so slicing is verifiable.
+            for k, pol in enumerate(('HH', 'HV')):
+                img = (np.arange(N_LINES)[:, None] * 1000 + np.arange(nrg)[None, :] + k * 0.5j).astype('c8')
+                g.create_dataset(pol, data=img, chunks=(8, min(8, nrg)), compression='gzip')
+            g.create_dataset('slantRange', data=slant)
+            g.create_dataset('slantRangeSpacing', data=float(slant[1] - slant[0]))
+            vs = np.tile([VALID_START, VALID_END], (N_LINES, 1)).astype('u4')
+            g.create_dataset('validSamplesSubSwath1', data=vs)
+            g.create_dataset('listOfPolarizations', data=np.array([b'HH', b'HV']))
+
+        # geolocationGrid: own coarse axes + 3-D [height, az, range] coordinate layers.
+        gl = f.create_group(_GEOLOC)
+        gl.create_dataset('heightAboveEllipsoid', data=GRID_HEIGHTS)
+        gl.create_dataset('zeroDopplerTime', data=GRID_AZ)
+        gl.create_dataset('slantRange', data=GRID_RG)
+        coord = np.broadcast_to(GRID_AZ[None, :, None] + GRID_RG[None, None, :], (N_H, N_AZG, N_RGG))
+        gl.create_dataset('coordinateX', data=coord.copy())
+        gl.create_dataset('coordinateY', data=coord.copy())
+        gl.create_dataset('epsg', data=np.int32(4326))
+
+        # identification times + footprint -> must be restamped to the cropped extent.
+        ident = f.create_group('science/LSAR/identification')
+        ident.create_dataset('zeroDopplerStartTime', data=np.bytes_('2025-01-01T00:00:00'))
+        ident.create_dataset('zeroDopplerEndTime', data=np.bytes_('2025-01-01T00:01:39'))
+        ident.create_dataset('boundingPolygon', data=np.bytes_('POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))'))
+
+        # A metadata dataset on no cropped axis -> must be copied byte-for-byte.
+        orb = f.create_dataset(
+            'science/LSAR/RSLC/metadata/orbit/position', data=np.arange(15, dtype='f8').reshape(5, 3)
+        )
+        orb.attrs['description'] = 'ECEF position'
+
+
+@pytest.fixture
+def rslc_h5(tmp_path):
+    path = tmp_path / 'synthetic_rslc.h5'
+    _make_rslc(path)
+    return path
+
+
+class TestWindowMath:
+    """The pure extent -> padded index slice logic, isce3-free."""
+
+    def test_az_and_range_windows_match_hand_derived(self):
+        assert _padded_slice(SWATH_T, AZ_LO, AZ_HI, MARGIN) == (26, 54)
+        assert _padded_slice(SLANT_A, RG_LO, RG_HI, MARGIN) == (32, 64)
+
+    def test_partial_overlap_is_clamped(self):
+        # Extent starts before the axis -> low bound clamps to 0.
+        assert _padded_slice(SLANT_A, -50.0, RG_HI, MARGIN)[0] == 0
+
+    def test_no_overlap_raises(self):
+        # Extent entirely past the end of the axis.
+        with pytest.raises(ValueError, match='does not overlap'):
+            _padded_slice(SWATH_T, 1e6, 2e6, MARGIN)
+
+    def test_non_monotonic_axis_raises(self):
+        # searchsorted would silently return garbage on an unsorted axis.
+        with pytest.raises(ValueError, match='increasing'):
+            _padded_slice(np.array([0.0, 2.0, 1.0, 3.0]), 0.0, 3.0, MARGIN)
+
+
+class TestCropRslc:
+    def test_shapes_and_axes(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        a0, a1 = EXPECTED_WINDOW['az']
+        with h5py.File(dst, 'r') as f:
+            # Shared azimuth axis sliced once.
+            assert f[f'{_SWATHS}/zeroDopplerTime'].shape == (a1 - a0,)
+            np.testing.assert_array_equal(f[f'{_SWATHS}/zeroDopplerTime'][()], SWATH_T[a0:a1])
+            for fr, slant in (('frequencyA', SLANT_A), ('frequencyB', SLANT_B)):
+                p0, p1 = EXPECTED_WINDOW[fr]
+                assert f[f'{_SWATHS}/{fr}/HH'].shape == (a1 - a0, p1 - p0)
+                assert f[f'{_SWATHS}/{fr}/HV'].shape == (a1 - a0, p1 - p0)
+                np.testing.assert_array_equal(f[f'{_SWATHS}/{fr}/slantRange'][()], slant[p0:p1])
+
+    def test_image_content_is_the_window(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        a0, a1 = EXPECTED_WINDOW['az']
+        p0, p1 = EXPECTED_WINDOW['frequencyA']
+        with h5py.File(rslc_h5, 'r') as src, h5py.File(dst, 'r') as out:
+            expect = src[f'{_SWATHS}/frequencyA/HH'][a0:a1, p0:p1]
+            np.testing.assert_array_equal(out[f'{_SWATHS}/frequencyA/HH'][()], expect)
+
+    def test_valid_samples_shifted_and_clipped(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        a0, a1 = EXPECTED_WINDOW['az']
+        p0, p1 = EXPECTED_WINDOW['frequencyA']
+        with h5py.File(dst, 'r') as f:
+            vs = f[f'{_SWATHS}/frequencyA/validSamplesSubSwath1'][()]
+        assert vs.shape == (a1 - a0, 2)
+        # start = clip(10 - 32, 0, 32) = 0 ; end = clip(110 - 32, 0, 32) = 32
+        expect = np.clip(np.array([VALID_START, VALID_END]) - p0, 0, p1 - p0)
+        np.testing.assert_array_equal(vs[0], expect)
+        assert (vs == expect).all()
+
+    def test_metadata_and_attrs_copied_verbatim(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        with h5py.File(rslc_h5, 'r') as src, h5py.File(dst, 'r') as out:
+            # Root attribute preserved.
+            assert out.attrs['mission_name'] == src.attrs['mission_name']
+            # Uncropped metadata dataset copied byte-for-byte, with its attrs.
+            o = out['science/LSAR/RSLC/metadata/orbit/position']
+            np.testing.assert_array_equal(o[()], src['science/LSAR/RSLC/metadata/orbit/position'][()])
+            assert o.attrs['description'] == 'ECEF position'
+            # Attribute on a cropped axis survives.
+            assert out[f'{_SWATHS}/zeroDopplerTime'].attrs['units'] == TIME_UNITS
+
+    def test_image_compression_preserved(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        with h5py.File(dst, 'r') as f:
+            ds = f[f'{_SWATHS}/frequencyA/HH']
+            assert ds.compression == 'gzip'
+            assert ds.chunks is not None
+
+    def test_geolocation_grid_bracketed(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        with h5py.File(dst, 'r') as f:
+            # Own axes bracketed to span the cropped swath extent.
+            np.testing.assert_array_equal(f[f'{_GEOLOC}/zeroDopplerTime'][()], GRID_AZ[EXPECTED_GRID_SLICE])
+            np.testing.assert_array_equal(f[f'{_GEOLOC}/slantRange'][()], GRID_RG[EXPECTED_GRID_SLICE])
+            # 3-D coordinate layer sliced on its trailing (az, range) dims only.
+            assert f[f'{_GEOLOC}/coordinateX'].shape == (N_H, 5, 5)
+            # Height axis and epsg are not on the radar grid -> untouched.
+            np.testing.assert_array_equal(f[f'{_GEOLOC}/heightAboveEllipsoid'][()], GRID_HEIGHTS)
+            assert f[f'{_GEOLOC}/epsg'][()] == 4326
+
+    def test_identification_times_restamped(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        with h5py.File(dst, 'r') as f:
+            assert f['science/LSAR/identification/zeroDopplerStartTime'][()].decode() == EXPECTED_START
+            assert f['science/LSAR/identification/zeroDopplerEndTime'][()].decode() == EXPECTED_END
+
+    def test_bounding_polygon_recomputed(self, rslc_h5, tmp_path):
+        dst = tmp_path / 'out.h5'
+        crop_rslc(rslc_h5, dst, EXPECTED_WINDOW, POLARIZATIONS)
+        with h5py.File(dst, 'r') as f:
+            wkt = f['science/LSAR/identification/boundingPolygon'][()].decode()
+        assert wkt.startswith('POLYGON ((') and '-180' not in wkt  # full-scene placeholder replaced
+        # Cropped geolocationGrid corners ([2:7] on both axes), coordinate = GRID_AZ + GRID_RG.
+        assert '44.000000 44.000000' in wkt  # (az 20, rg 24)
+        assert '132.000000 132.000000' in wkt  # (az 60, rg 72)
+
+
+class TestCropPair:
+    def test_pair_writes_two_files(self, rslc_h5, tmp_path, monkeypatch):
+        # The NISAR reader + geo2rdr window solve need isce3; stub the reader and
+        # both reader-using steps so the pair plumbing (per-file crop + naming) is testable.
+        monkeypatch.setattr(crop_mod, 'SLC', lambda **k: None)
+        monkeypatch.setattr(crop_mod, 'aoi_to_radar_window', lambda *a, **k: EXPECTED_WINDOW)
+        monkeypatch.setattr(crop_mod, 'get_polarizations', lambda *a, **k: POLARIZATIONS)
+        # A real pair is two distinct files (different acquisition dates);
+        # mimic that so the per-file output names don't collide.
+        sec = tmp_path / 'synthetic_rslc_sec.h5'
+        _make_rslc(sec)
+        ref_sub, sec_sub = crop_rslc_pair(
+            rslc_h5, sec, bbox_wgs84=None, dem_file=None, out_dir=tmp_path / 'subs', margin=MARGIN
+        )
+        for p in (ref_sub, sec_sub):
+            assert Path(p).exists()
+            with h5py.File(p, 'r') as f:
+                a0, a1 = EXPECTED_WINDOW['az']
+                assert f[f'{_SWATHS}/zeroDopplerTime'].shape == (a1 - a0,)
+        assert ref_sub != sec_sub
+
+
+class TestBand:
+    def test_returns_lsar(self, tmp_path):
+        path = tmp_path / 'b.h5'
+        with h5py.File(path, 'w') as f:
+            f.create_group('science/LSAR/RSLC')
+        with h5py.File(path, 'r') as f:
+            assert _band(f) == 'LSAR'
+
+    def test_returns_ssar(self, tmp_path):
+        path = tmp_path / 'b.h5'
+        with h5py.File(path, 'w') as f:
+            f.create_group('science/SSAR/RSLC')
+        with h5py.File(path, 'r') as f:
+            assert _band(f) == 'SSAR'
+
+    def test_no_rslc_band_raises(self, tmp_path):
+        path = tmp_path / 'b.h5'
+        with h5py.File(path, 'w') as f:
+            f.create_group('science/LSAR/GCOV')  # a band group, but not RSLC
+        with h5py.File(path, 'r') as f, pytest.raises(ValueError, match='No RSLC band'):
+            _band(f)
+
+
+class TestBracket:
+    def test_brackets_extent_one_node_outside(self):
+        axis = np.arange(10, dtype='f8') * 10.0  # 0, 10, ..., 90
+        # searchsorted(right, 26)=3 -> 2 ; searchsorted(left, 53)=6 -> 7
+        assert _bracket(axis, 26.0, 53.0) == (2, 7)
+
+    def test_clamps_to_axis_bounds(self):
+        axis = np.arange(10, dtype='f8') * 10.0
+        assert _bracket(axis, -100.0, 1000.0) == (0, 10)
+
+
+class TestEpochAlignment:
+    def test_aligned_ok(self):
+        # sensing_start == swath_t[0] -> no raise.
+        _check_epoch_alignment(SimpleNamespace(sensing_start=0.0), np.arange(100, dtype='f8'))
+
+    def test_within_half_sample_ok(self):
+        # Offset below half an azimuth sample (spacing 1.0) -> no raise.
+        _check_epoch_alignment(SimpleNamespace(sensing_start=0.4), np.arange(100, dtype='f8'))
+
+    def test_misaligned_raises(self):
+        with pytest.raises(RuntimeError, match='epoch'):
+            _check_epoch_alignment(SimpleNamespace(sensing_start=5.0), np.arange(100, dtype='f8'))
+
+
+class TestGetPolarizations:
+    def test_maps_each_frequency_to_its_pols(self):
+        slc = SimpleNamespace(frequencies=['A', 'B'], polarizations={'A': ['HH', 'HV'], 'B': ['VV']})
+        assert get_polarizations(slc) == {'frequencyA': ['HH', 'HV'], 'frequencyB': ['VV']}
+
+
+def test_copy_attrs(tmp_path):
+    path = tmp_path / 'a.h5'
+    with h5py.File(path, 'w') as f:
+        src = f.create_dataset('src', data=[1, 2, 3])
+        src.attrs['units'] = 'meters'
+        src.attrs['scale'] = 2.0
+        dst = f.create_dataset('dst', data=[0])
+        _copy_attrs(src, dst)
+        assert dst.attrs['units'] == 'meters'
+        assert dst.attrs['scale'] == 2.0
+
+
+def test_mirror_except_prunes_subtree(tmp_path):
+    src_path, dst_path = tmp_path / 'src.h5', tmp_path / 'dst.h5'
+    with h5py.File(src_path, 'w') as f:
+        f.attrs['mission'] = 'NISAR'  # root attr -> copied
+        f.create_dataset('a/keep', data=[1, 2])  # sibling of the pruned subtree
+        f.create_dataset('a/drop/x', data=[9])  # inside the pruned subtree
+        f.create_dataset('top', data=[7])  # unrelated branch
+    with h5py.File(src_path, 'r') as src, h5py.File(dst_path, 'w') as dst:
+        _mirror_except(src, dst, {'a/drop'})
+    with h5py.File(dst_path, 'r') as out:
+        assert out.attrs['mission'] == 'NISAR'
+        assert 'a' in out  # ancestor of the pruned path is still created
+        assert 'a/keep' in out  # sibling copied verbatim
+        assert 'top' in out  # unrelated branch copied wholesale
+        assert 'a/drop' not in out  # pruned subtree skipped for the caller to fill

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
-from hyp3_isce3.process import get_config
+from hyp3_isce3.process import get_config, reproject_subset
 
 
-def test_get_config(mocker):
+def test_get_config(mocker, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # get_config writes temp.yaml/insar.yaml to cwd
     reference_path = 'REFERENCE_TEST.h5'
     secondary_path = 'SECONDARY_TEST.h5'
 
@@ -16,12 +17,11 @@ def test_get_config(mocker):
     tec_path = 'TEC.json'
     watermask = 'WATERMASK.vrt'
 
-    tmp_path = Path('temp.yaml')
-    with tmp_path.open('w') as tmp:
-        tmp.write('partial_granule_id:')
+    temp_yaml = Path('temp.yaml')
+    temp_yaml.write_text('partial_granule_id:')
 
     mock_func = mocker.patch('hyp3_isce3.process.download_yaml')
-    mock_func.return_value = tmp_path
+    mock_func.return_value = temp_yaml
 
     yaml = get_config(
         reference_path,
@@ -62,3 +62,70 @@ def test_get_config(mocker):
                 exists_tec = True
     assert exists_reference and exists_secondary and exists_watermask and exists_orbits and exists_tropo and exists_tec
     assert 'partial_granule_id:' in lines[-1]
+
+
+def test_reproject_subset():
+    # AOI straddling the UTM zone 11N central meridian (117W, easting 500000).
+    xmin, ymin, xmax, ymax = reproject_subset([-117.1, 46.0, -116.9, 46.2], 32611)
+    assert xmin < xmax and ymin < ymax
+    assert 490_000 < xmin < 500_000 < xmax < 510_000
+    assert 5_000_000 < ymin < ymax < 5_200_000
+
+
+def test_get_config_subset(mocker, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    # Downloaded GUNW runconfig tail (from product_path_group on) with the geocode
+    # and radar_grid_cubes blocks, plus a dem_download block that uses x/y.
+    tail = (
+        'product_path_group:\n'
+        '    sas_output_file: output/GUNW_product.h5\n'
+        'processing:\n'
+        '    dem_download:\n'
+        '        top_left:\n'
+        '            x: 1.0\n'
+        '            y: 2.0\n'
+        '        bottom_right:\n'
+        '            x: 3.0\n'
+        '            y: 4.0\n'
+        '    geocode:\n'
+        '        output_epsg: 9999\n'
+        '        top_left:\n'
+        '            y_abs: 0.0\n'
+        '            x_abs: 0.0\n'
+        '        bottom_right:\n'
+        '            y_abs: 0.0\n'
+        '            x_abs: 0.0\n'
+        '    radar_grid_cubes:\n'
+        '        output_epsg: 9999\n'
+        '        top_left:\n'
+        '            y_abs: 0.0\n'
+        '            x_abs: 0.0\n'
+        '        bottom_right:\n'
+        '            y_abs: 0.0\n'
+        '            x_abs: 0.0\n'
+        'partial_granule_id: foo\n'
+    )
+    Path('temp.yaml').write_text(tail)
+    mocker.patch('hyp3_isce3.process.download_yaml', return_value=Path('temp.yaml'))
+
+    yaml_path = get_config(
+        'REF.h5',
+        'SEC.h5',
+        'REFORB.xml',
+        'SECORB.xml',
+        'REFTROP.nc',
+        'SECTROP.nc',
+        'TEC.json',
+        'WMASK.vrt',
+        subset_utm=(100.0, 200.0, 300.0, 400.0),
+        output_epsg=32611,
+    )
+    text = yaml_path.read_text()
+    # output_epsg pinned to the AOI zone on both geocode and radar_grid_cubes.
+    assert text.count('output_epsg: 32611') == 2
+    assert 'output_epsg: 9999' not in text
+    # top_left = (xmin, ymax), bottom_right = (xmax, ymin), in both blocks.
+    assert text.count('x_abs: 100.0') == 2 and text.count('y_abs: 400.0') == 2
+    assert text.count('x_abs: 300.0') == 2 and text.count('y_abs: 200.0') == 2
+    # dem_download uses x/y (not x_abs/y_abs) and is left untouched.
+    assert all(s in text for s in ('x: 1.0', 'y: 2.0', 'x: 3.0', 'y: 4.0'))

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
-from hyp3_isce3.process import get_config, reproject_subset
+from hyp3_isce3.process import get_config, get_crossmul_looks, reproject_subset
 
 
-def test_get_config(mocker, monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)  # get_config writes temp.yaml/insar.yaml to cwd
+def test_get_config(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # get_config writes insar.yaml to cwd
     reference_path = 'REFERENCE_TEST.h5'
     secondary_path = 'SECONDARY_TEST.h5'
 
@@ -20,9 +20,6 @@ def test_get_config(mocker, monkeypatch, tmp_path):
     temp_yaml = Path('temp.yaml')
     temp_yaml.write_text('partial_granule_id:')
 
-    mock_func = mocker.patch('hyp3_isce3.process.download_yaml')
-    mock_func.return_value = temp_yaml
-
     yaml = get_config(
         reference_path,
         secondary_path,
@@ -32,6 +29,7 @@ def test_get_config(mocker, monkeypatch, tmp_path):
         secondary_tropo,
         tec_path,
         watermask,
+        temp_yaml,
     )
     exists_reference = False
     exists_secondary = False
@@ -64,6 +62,14 @@ def test_get_config(mocker, monkeypatch, tmp_path):
     assert 'partial_granule_id:' in lines[-1]
 
 
+def test_get_crossmul_looks(tmp_path):
+    rc = tmp_path / 'rc.yaml'
+    rc.write_text(
+        'runconfig:\n  groups:\n    processing:\n      crossmul:\n        range_looks: 7\n        azimuth_looks: 16\n'
+    )
+    assert get_crossmul_looks(rc) == (16, 7)
+
+
 def test_reproject_subset():
     # AOI straddling the UTM zone 11N central meridian (117W, easting 500000).
     xmin, ymin, xmax, ymax = reproject_subset([-117.1, 46.0, -116.9, 46.2], 32611)
@@ -72,7 +78,7 @@ def test_reproject_subset():
     assert 5_000_000 < ymin < ymax < 5_200_000
 
 
-def test_get_config_subset(mocker, monkeypatch, tmp_path):
+def test_get_config_subset(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     # Downloaded GUNW runconfig tail (from product_path_group on) with the geocode
     # and radar_grid_cubes blocks, plus a dem_download block that uses x/y.
@@ -106,7 +112,6 @@ def test_get_config_subset(mocker, monkeypatch, tmp_path):
         'partial_granule_id: foo\n'
     )
     Path('temp.yaml').write_text(tail)
-    mocker.patch('hyp3_isce3.process.download_yaml', return_value=Path('temp.yaml'))
 
     yaml_path = get_config(
         'REF.h5',
@@ -117,6 +122,7 @@ def test_get_config_subset(mocker, monkeypatch, tmp_path):
         'SECTROP.nc',
         'TEC.json',
         'WMASK.vrt',
+        Path('temp.yaml'),
         subset_utm=(100.0, 200.0, 300.0, 400.0),
         output_epsg=32611,
     )


### PR DESCRIPTION
  Add --subset to crop RSLCs to an AOI before GUNW processing

**Summary**

  Adds an optional --subset LON_MIN LAT_MIN LON_MAX LAT_MAX (WGS84) parameter that subsets the RSLC→GUNW workflow to an area of interest. When set, the input RSLCs are cropped in radar coordinates before processing, so every radar-domain step (rdr2geo, geo2rdr, resample, crossmul, unwrap, …) runs on a small patch instead of the full frame, and the geocoded output is bounded to the AOI.

 **Motivation**

  The isce3 InSAR pipeline runs all pre-geocoding steps in radar geometry over the full RSLC swath, so a geocode bounding box alone doesn't make a run cheaper — the inputs have to be small. Cropping the RSLCs before processing is the big speedup.

**Testing**

  - added in tests of new process wgs84 box to utm (for final geocode step)
  - added in tests of most of rslc cropping functions

 **Notes**

  - --subset is WGS84 lon/lat. Could do utm or radar coords but I can't see a need?
  - keep full sized metadata radar cubes since they work for isce3 processing (it auto crops to extent) but we could crop those too?